### PR TITLE
fix: use patch bumps for feat commits while pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `bump-patch-for-minor-pre-major: true` to release-please config
- While version is 0.x, `feat:` commits bump patch (0.1.0→0.1.1) instead of minor (0.1.0→0.2.0)
- Closed stale 0.2.0 release PR (#3)