### PR TITLE
feat: add edit token for write protection

### DIFF
--- a/.claude/agents/security-audit.md
+++ b/.claude/agents/security-audit.md
@@ -1,0 +1,117 @@
+---
+name: security-audit
+description: Deep security audit of livedown codebase, focusing on local file access, WebSocket, command injection, and XSS vulnerabilities
+color: red
+---
+
+You are a security auditor performing a thorough code review of the livedown project. This tool shares local files over the internet via WebSocket relay — making security critical.
+
+## Your Mission
+
+Audit every source file for security vulnerabilities. Be exhaustive and specific — cite exact file paths, line numbers, and code snippets. Categorize findings by severity (Critical, High, Medium, Low, Info).
+
+## Key Attack Surfaces
+
+This project has several high-risk attack surfaces you MUST examine:
+
+### 1. Local File System Access (CRITICAL PRIORITY)
+
+The watcher (`src/watcher.ts`) writes content received from remote WebSocket messages directly to the local file system. This is the most dangerous surface:
+
+- **Remote write-back to local disk**: `fs.writeFileSync(filePath, newRaw, "utf8")` writes content from any connected WebSocket client to the user's local file. An attacker who joins the room can overwrite the shared file with arbitrary content.
+- **Path traversal**: Check whether file paths can be manipulated to write outside the intended directory.
+- **YAML frontmatter injection**: The `meta.owner`, `meta.github_repo`, and `meta.title` fields from remote messages are interpolated into YAML frontmatter and written to disk. Check for YAML injection (e.g., injecting newlines or YAML directives to corrupt the file).
+- **File read on connect**: The watcher reads and transmits the full file content on WebSocket open — verify no sensitive data leaks through metadata.
+
+### 2. Command Injection
+
+`src/cli.ts` uses `execSync` to open URLs in the browser:
+```typescript
+execSync(`${cmd} ${JSON.stringify(url)}`, { stdio: "ignore" });
+```
+- Check whether the URL argument can escape `JSON.stringify` quoting and inject shell commands.
+- Check if the `open`/`xdg-open` commands have their own injection vectors.
+
+### 3. WebSocket Security
+
+- **No authentication**: Anyone who knows or guesses a room URL can connect, read content, and push updates.
+- **No message validation**: The relay (`src/party/livedown.ts`) does not validate message structure, size, or content before broadcasting.
+- **No rate limiting**: A malicious client could flood the relay with messages.
+- **Session ID entropy**: `shortId()` generates only 6 hex chars (16.7M possibilities) — feasible to brute-force.
+- **No TLS certificate validation on WebSocket client** (check `ws` library defaults).
+
+### 4. Cross-Site Scripting (XSS)
+
+The browser viewer (`public/index.html`) renders markdown and metadata:
+- **Markdown rendering**: Check if `marked.js` sanitizes HTML or allows script injection through markdown.
+- **Meta field injection**: Fields like `editor`, `title`, `owner` are displayed in the UI — check for DOM-based XSS.
+- **innerHTML usage**: Search for direct `innerHTML` assignments with unsanitized content.
+
+### 5. Denial of Service
+
+- **Large message handling**: No size limits on WebSocket messages — an attacker could send massive payloads.
+- **Reconnection amplification**: The auto-reconnect logic could be exploited to create connection storms.
+- **Resource exhaustion**: The chokidar file watcher has no limits on file size.
+
+### 6. Information Disclosure
+
+- **Hostname leak**: The default editor name is `os.hostname()` — leaks the user's machine name.
+- **File path leak**: The `meta.file` field contains the document name, potentially revealing directory structure.
+- **Error messages**: Check if error handling leaks sensitive information.
+
+### 7. Dependency Security
+
+- Check for known vulnerabilities in key dependencies (`ws`, `chokidar`, `commander`, `gray-matter`, `marked`).
+- Review if dependencies are pinned to safe versions.
+
+## Audit Process
+
+1. Read every source file completely (there are only 4 TypeScript files and 1 HTML file)
+2. For each attack surface above, trace data flow from input to dangerous operation
+3. Check for missing input validation, sanitization, and access controls
+4. Look for race conditions (e.g., the `ignoreNextWrite` flag in the watcher)
+5. Review the PartyKit relay for server-side vulnerabilities
+6. Check dependency versions against known CVE databases
+
+## Output Format
+
+Produce a structured report:
+
+```markdown
+# Livedown Security Audit
+
+## Executive Summary
+[2-3 sentence overview of findings]
+
+## Critical Findings
+### [CRIT-001] Title
+- **File**: path:line
+- **Description**: What the vulnerability is
+- **Impact**: What an attacker can do
+- **Proof of Concept**: How to exploit it
+- **Remediation**: How to fix it
+
+## High Findings
+### [HIGH-001] Title
+...
+
+## Medium Findings
+...
+
+## Low Findings
+...
+
+## Informational
+...
+
+## Recommendations
+[Prioritized list of security improvements]
+```
+
+## Important
+
+- Read ALL source files. Do not skip any.
+- Be specific — cite exact line numbers and code.
+- Provide actionable remediation for every finding.
+- Focus especially on the local file write-back vulnerability — this is the most dangerous feature of the tool.
+- Consider the threat model: the user is sharing a file with potentially untrusted viewers who can edit.

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -40,6 +40,20 @@ If a credential is included in a broadcast message, every recipient has it. Shar
 
 **Correct approach**: using asymmetric signing (Ed25519). The public key is broadcast freely for verification. The private key (edit key) is only held by authorized editors. Viewers can verify authenticity but cannot forge.
 
+### 4. Never implement cryptographic code — use verified libraries
+
+Cryptographic operations must use established, audited libraries. Never write custom implementations of signing, hashing, key derivation, or encryption — even for "simple" operations.
+
+**Bad example**: extracting Ed25519 verify functions from a library into a standalone file, or implementing hex-to-bytes conversion with custom math for cryptographic contexts.
+
+**Correct approach**: import a verified library (`tweetnacl`, `@noble/curves`, etc.) and use its public API directly. If a library doesn't work in a specific environment (e.g., bundler incompatibility), use a different verified library — do not extract or rewrite the code.
+
+The current approved cryptographic libraries for livedown are:
+- **tweetnacl** — Ed25519 signing/verification in Node.js (CLI, watcher) and browser (CDN)
+- **@noble/curves** — Ed25519 verification in the relay (Cloudflare Workers compatible, pure ESM)
+
+Both implement RFC 8032 Ed25519 and produce compatible signatures. Any change to cryptographic libraries must be flagged as a principle violation if it introduces custom implementations.
+
 ## Key Attack Surfaces
 
 This project has several high-risk attack surfaces you MUST examine:

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -1,14 +1,44 @@
 ---
-name: security-audit
-description: Deep security audit of livedown codebase, focusing on local file access, WebSocket, command injection, and XSS vulnerabilities
+name: security
+description: Security review of livedown — audit vulnerabilities, validate architectural decisions, and enforce security principles
 color: red
 ---
 
-You are a security auditor performing a thorough code review of the livedown project. This tool shares local files over the internet via WebSocket relay — making security critical.
+You are a security reviewer for the livedown project. This tool shares local files over the internet via WebSocket relay — making security critical.
 
 ## Your Mission
 
 Audit every source file for security vulnerabilities. Be exhaustive and specific — cite exact file paths, line numbers, and code snippets. Categorize findings by severity (Critical, High, Medium, Low, Info).
+
+Also evaluate the codebase against the security principles below. Flag any violations.
+
+## Security Principles
+
+These are architectural rules for livedown. Any code that violates them is a finding.
+
+### 1. URLs are locators, not credentials
+
+A URL must never grant authorization. URLs leak through browser history, Slack previews, referrer headers, bookmarks, and shoulder surfing. If someone forwards a URL, it should not give the recipient edit access.
+
+**Bad example**: embedding an edit key in the URL fragment (`https://relay/#docId?key=SECRET`). Anyone who receives that link — intentionally or accidentally — gets write access to the sharer's local file.
+
+**Correct approach**: the URL identifies the document; the edit key is a separate credential entered out-of-band (pasted into a prompt, passed as a CLI flag).
+
+### 2. Defense in depth — never trust a single enforcement point
+
+Every component that can reject unauthorized actions MUST do so independently. If the relay is compromised, the local watcher must still refuse unsigned/unauthorized updates. If the browser is compromised, the relay must still reject unauthorized pushes.
+
+**Bad example**: only the relay validates edit tokens, and the watcher writes any `update` message to disk without checking.
+
+**Correct approach**: the relay validates signatures before broadcasting, AND the watcher validates signatures before writing to disk. An attacker must compromise both to write to the sharer's file.
+
+### 3. Secrets must never transit through broadcast channels
+
+If a credential is included in a broadcast message, every recipient has it. Shared secrets embedded in relay-broadcast messages become public knowledge.
+
+**Bad example**: including the edit token in `update` messages so the watcher can verify it — every viewer now has the token and can forge pushes.
+
+**Correct approach**: using asymmetric signing (Ed25519). The public key is broadcast freely for verification. The private key (edit key) is only held by authorized editors. Viewers can verify authenticity but cannot forge.
 
 ## Key Attack Surfaces
 
@@ -66,12 +96,13 @@ The browser viewer (`public/index.html`) renders markdown and metadata:
 
 ## Audit Process
 
-1. Read every source file completely (there are only 4 TypeScript files and 1 HTML file)
-2. For each attack surface above, trace data flow from input to dangerous operation
-3. Check for missing input validation, sanitization, and access controls
-4. Look for race conditions (e.g., the `ignoreNextWrite` flag in the watcher)
-5. Review the PartyKit relay for server-side vulnerabilities
-6. Check dependency versions against known CVE databases
+1. Read every source file completely
+2. Evaluate against the security principles — flag any violations
+3. For each attack surface above, trace data flow from input to dangerous operation
+4. Check for missing input validation, sanitization, and access controls
+5. Look for race conditions (e.g., the `ignoreNextWrite` flag in the watcher)
+6. Review the PartyKit relay for server-side vulnerabilities
+7. Check dependency versions against known CVE databases
 
 ## Output Format
 
@@ -82,6 +113,13 @@ Produce a structured report:
 
 ## Executive Summary
 [2-3 sentence overview of findings]
+
+## Principle Violations
+### [PRINC-001] Title
+- **Principle**: Which security principle is violated
+- **Where**: File path and description
+- **Impact**: What could go wrong
+- **Remediation**: How to fix it
 
 ## Critical Findings
 ### [CRIT-001] Title

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+-
+
+## Screenshots
+
+> UI changes must include before/after screenshots. CLI changes should include before/after terminal screenshots for any non-trivial change.
+
+### Before
+
+
+### After
+

--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -1,0 +1,17 @@
+name: Agent Actions
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  claude:
+    uses: dwmkerr/agent-actions/.github/workflows/claude.yml@main
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,29 @@
+name: deploy
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [cicd]
+    types: [completed]
+    branches: [main]
+
+env:
+  NODE_LTS_VERSION: 24.x
+
+jobs:
+  deploy-partykit:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_LTS_VERSION }}
+          cache: "npm"
+      - run: npm ci
+      - run: npx partykit deploy
+        env:
+          PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}

--- a/.github/workflows/security-review.yaml
+++ b/.github/workflows/security-review.yaml
@@ -1,21 +1,28 @@
 name: security-review
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, synchronize, labeled]
 
 jobs:
   security-review:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    # Only runs on release-please branches — bot-generated, can't be pushed
+    # to by external contributors. The label check is a secondary guard.
+    if: >
+      startsWith(github.head_ref, 'release-please--')
+      && contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     permissions:
       contents: read
       pull-requests: write
     steps:
+      # Checkout from BASE (main), not the PR branch. This ensures the
+      # workflow, agent definition, and prompt all come from trusted code.
+      # We only read the PR diff via gh cli — never checkout PR code.
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Get changed files
         id: changes
@@ -32,19 +39,36 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Get PR diff
+        if: steps.changes.outputs.skip == 'false'
+        id: diff
+        run: |
+          DIFF=$(gh pr diff ${{ github.event.pull_request.number }})
+          echo "diff<<DIFFEOF" >> "$GITHUB_OUTPUT"
+          echo "$DIFF" >> "$GITHUB_OUTPUT"
+          echo "DIFFEOF" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Run security review
         if: steps.changes.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # allowed_tools restricts Claude to read-only — no bash, no writes
+          allowed_tools: "Read,Glob,Grep"
           direct_prompt: |
             You are the livedown security agent. Read .claude/agents/security.md for your full instructions and security principles.
 
-            This is a release PR. Review ALL changed source files for security issues.
+            This is a release PR. Review the diff below for security issues.
 
             Changed files:
             ${{ steps.changes.outputs.files }}
 
-            Read each changed file and evaluate against the security principles and attack surfaces defined in .claude/agents/security.md. Post your findings as a structured report. If there are no issues, confirm the release is safe.
+            Read each changed file in the CURRENT codebase (checked out from main) and review the diff to evaluate changes against the security principles and attack surfaces defined in .claude/agents/security.md.
+
+            Post your findings as a structured report. If there are no issues, confirm the release is safe.
+
+            IMPORTANT: You are reviewing code for security. Do not execute any code, do not run any commands, do not access any URLs. Only read files and analyze.
 
             Focus on: file system write-back, signature verification, XSS, credential handling, and the four security principles (URLs not credentials, defense in depth, no broadcast secrets, no custom crypto).

--- a/.github/workflows/security-review.yaml
+++ b/.github/workflows/security-review.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   security-review:
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'release-please--') && contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    if: "startsWith(github.head_ref, 'release-please--') && contains(github.event.pull_request.labels.*.name, 'autorelease: pending')"
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/security-review.yaml
+++ b/.github/workflows/security-review.yaml
@@ -1,0 +1,50 @@
+name: security-review
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, labeled]
+
+jobs:
+  security-review:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changes
+        run: |
+          FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | grep -E '\.(ts|js|html|json)$' || true)
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$FILES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          if [ -z "$FILES" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Run security review
+        if: steps.changes.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          direct_prompt: |
+            You are the livedown security agent. Read .claude/agents/security.md for your full instructions and security principles.
+
+            This is a release PR. Review ALL changed source files for security issues.
+
+            Changed files:
+            ${{ steps.changes.outputs.files }}
+
+            Read each changed file and evaluate against the security principles and attack surfaces defined in .claude/agents/security.md. Post your findings as a structured report. If there are no issues, confirm the release is safe.
+
+            Focus on: file system write-back, signature verification, XSS, credential handling, and the four security principles (URLs not credentials, defense in depth, no broadcast secrets, no custom crypto).

--- a/.github/workflows/security-review.yaml
+++ b/.github/workflows/security-review.yaml
@@ -8,11 +8,7 @@ on:
 jobs:
   security-review:
     runs-on: ubuntu-latest
-    # Only runs on release-please branches — bot-generated, can't be pushed
-    # to by external contributors. The label check is a secondary guard.
-    if: >
-      startsWith(github.head_ref, 'release-please--')
-      && contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    if: startsWith(github.head_ref, 'release-please--') && contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     permissions:
       contents: read
       pull-requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ scratch/
 *.env
 !*.env.sample
 .partykit/
+.playwright-mcp/
+coverage/
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+## Project
+
+Livedown shares local markdown files live via WebSocket. Security is critical — the tool writes remote content to local disk.
+
+## Architecture
+
+See README.md "How It Works" for the architecture diagram, component descriptions, key libraries, and security model. **This documentation must be kept up to date** — any PR that changes the architecture, adds/removes dependencies, or modifies the security model must update the README accordingly.
+
+Specifically, keep current:
+- The architecture diagram and component descriptions
+- The "Key Libraries" table (add/remove entries when dependencies change)
+- The "Security" section (update when auth/signing logic changes)
+- The "PartyKit and Cloudflare Workers" section (update when relay infrastructure changes)
+
+## Security
+
+Run the security agent (`.claude/agents/security.md`) before merging security-sensitive changes. It enforces four principles:
+
+1. URLs are locators, not credentials
+2. Defense in depth — every component validates independently
+3. Secrets never transit broadcast channels
+4. Never implement crypto — use verified libraries (tweetnacl, @noble/curves)
+
+## Conventions
+
+- Conventional commits required (`feat:`, `fix:`, `docs:`, `chore:`)
+- UI changes require before/after screenshots in PRs
+- CLI changes should include terminal screenshots for non-trivial changes
+- Never add breadcrumb comments — only explain *why*, not *what*
+
+## Key Files
+
+- `src/token.ts` — Ed25519 keypair generation, signing, verification (tweetnacl)
+- `src/party/livedown.ts` — relay server, signature verification (@noble/curves)
+- `src/watcher.ts` — file watcher, signs pushes, verifies incoming updates
+- `src/cli.ts` — CLI entry point, generates edit key
+- `public/index.html` — browser viewer (tweetnacl via CDN)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## Getting Started
+
+```bash
+git clone git@github.com:dwmkerr/livedown.git
+cd livedown
+npm install
+npm run build
+npm link
+livedown share ./README.md
+```
+
+## Development
+
+Run the relay locally:
+
+```bash
+npx partykit dev
+```
+
+In another terminal, share a file against the local relay:
+
+```bash
+PARTYKIT_HOST=localhost:1999 npx ts-node src/cli.ts share README.md
+```
+
+## Pull Requests
+
+All PRs must follow conventional commit format for titles (e.g., `feat:`, `fix:`, `docs:`).
+
+### Screenshots Required
+
+- **UI changes** must include before/after screenshots showing the visual difference
+- **CLI changes** should include before/after terminal screenshots for any non-trivial change (new output, changed prompts, modified formatting)
+
+### PR Template
+
+Use the standard summary format:
+
+```markdown
+## Summary
+- Brief description of changes
+
+## Screenshots
+### Before
+<!-- screenshot -->
+
+### After
+<!-- screenshot -->
+```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ Livedown has three components:
 
 3. **Browser Viewer** (`public/index.html`) — renders the shared markdown with live preview and a CodeMirror editor. Viewers can read freely; editing requires the edit key.
 
+### Key Libraries
+
+| Library | Used In | Purpose |
+|---------|---------|---------|
+| [tweetnacl](https://github.com/nickolay/nickolay/tweetnacl-js) | CLI, watcher, browser (CDN) | Ed25519 signing and verification |
+| [@noble/curves](https://github.com/paulmillr/noble-curves) | Relay | Ed25519 verification (pure ESM, Cloudflare Workers compatible) |
+| [PartyKit](https://partykit.io) | Relay | WebSocket relay infrastructure on Cloudflare Workers |
+| [CodeMirror](https://codemirror.net) | Browser | Markdown editor |
+| [marked](https://marked.js.org) | Browser | Markdown to HTML rendering |
+| [chokidar](https://github.com/paulmillr/chokidar) | Watcher | File system change detection |
+| [commander](https://github.com/tj/commander.js) | CLI | Command-line argument parsing |
+
 ### Security
 
 Livedown uses **Ed25519 asymmetric signing** to protect the sharer's local files from unauthorized edits.
@@ -88,9 +100,9 @@ This means even a compromised relay cannot forge updates that the local watcher 
 
 ### PartyKit and Cloudflare Workers
 
-The relay runs on [PartyKit](https://partykit.io), which deploys to [Cloudflare Workers](https://workers.cloudflare.com). The relay uses the Web Crypto API (`crypto.subtle.verify` with Ed25519) for signature verification — no external dependencies in the deployed bundle.
+The relay runs on [PartyKit](https://partykit.io), which deploys to [Cloudflare Workers](https://workers.cloudflare.com). The relay uses [@noble/curves](https://github.com/paulmillr/noble-curves) for Ed25519 signature verification — a pure ESM library with no Node.js dependencies that bundles cleanly in Cloudflare's esbuild pipeline.
 
-The CLI and browser use [tweetnacl](https://github.com/nickolay/nickolay/tweetnacl-js) for Ed25519 operations. Both implementations use the same Ed25519 curve and produce compatible signatures.
+The CLI and browser use [tweetnacl](https://github.com/nickolay/nickolay/tweetnacl-js) for Ed25519 operations. Both libraries implement RFC 8032 Ed25519 and produce compatible signatures.
 
 Rooms are ephemeral — they exist only while connections are active and have no persistent storage. The public key is held in memory for the room's lifetime and must be re-registered on each sharing session.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-testing
-
 <p align="center">
   <h2 align="center"><code>📝 livedown</code></h2>
   <h3 align="center">Share a local markdown file and collaborate live in a browser and across machines.</h3>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ title: "README"
 ---
 <p align="center">
   <h2 align="center"><code>📝 livedown</code></h2>
-  <h3 align="center">Edit markdown locally, share it live in a browser.</h3>
+  <h3 align="center">Share a local markdown file and collaborate live in a browser and across machines.</h3>
   <p align="center">
     <a href="#quickstart">Quickstart</a> |
     <a href="#how-it-works">How It Works</a> |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+testing
+
 <p align="center">
   <h2 align="center"><code>📝 livedown</code></h2>
   <h3 align="center">Share a local markdown file and collaborate live in a browser and across machines.</h3>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
     <a href="#how-it-works">How It Works</a> |
     <a href="#commands">Commands</a>
   </p>
-  
-  
-  
+
+
+
   <p align="center">
     <a href="https://github.com/dwmkerr/livedown/actions/workflows/cicd.yaml"><img src="https://github.com/dwmkerr/livedown/actions/workflows/cicd.yaml/badge.svg" alt="cicd"></a>
     <a href="https://www.npmjs.com/package/@dwmkerr/livedown"><img src="https://img.shields.io/npm/v/%40dwmkerr/livedown" alt="npm version"></a>
@@ -22,19 +22,7 @@
 npx @dwmkerr/livedown share ./your-file.md
 ```
 
-Open the printed URL — anyone with the link sees your edits in real time and can edit the file as well.
-
-> [!WARNING]
-> **Work in Progress** — livedown exposes the contents of local files over the internet. Guardrails to prevent unintended file exposure are being developed. Use with caution and avoid sharing sensitive files.
-
-## How It Works
-
-```
- Your Machine          livedown.dev          Collaborator
- ┌──────────┐         ┌──────────┐          ┌──────────┐
- │ notes.md │◀───────▶│          │◀────────▶│ Browser  │
- └──────────┘         └──────────┘          └──────────┘
-```
+Open the printed URL — anyone with the link can view your document in real time. To edit, they need the edit key.
 
 ## Commands
 
@@ -46,6 +34,11 @@ Watch a local file and share it live.
 livedown share ./notes.md
 ```
 
+Options:
+- `-r, --relay <host>` — Relay host (default: `livedown.dwmkerr.partykit.dev`)
+- `-e, --editor <name>` — Your name shown to viewers
+- `-k, --edit-key <key>` — Edit key (auto-generated if omitted)
+
 ### `livedown open <url>`
 
 Open a shared document in the browser.
@@ -54,16 +47,56 @@ Open a shared document in the browser.
 livedown open https://livedown.dwmkerr.partykit.dev/#abc123/notes.md
 ```
 
+## How It Works
+
+```
+ Your Machine             Relay (PartyKit)          Collaborator
+ ┌──────────┐            ┌──────────────┐          ┌──────────┐
+ │ notes.md │───signed──▶│  Verify sig  │──update─▶│ Browser  │
+ │          │◀──verify───│  Broadcast   │◀─signed──│          │
+ └──────────┘            └──────────────┘          └──────────┘
+   watcher                 Cloudflare                viewer
+   (Node.js)               Workers                   (HTML)
+```
+
+Livedown has three components:
+
+1. **CLI / Watcher** (`src/cli.ts`, `src/watcher.ts`) — watches a local markdown file for changes, pushes signed updates to the relay via WebSocket, and writes verified incoming updates to disk.
+
+2. **Relay** (`src/party/livedown.ts`) — a [PartyKit](https://partykit.io) server running on Cloudflare Workers. Accepts WebSocket connections, verifies Ed25519 signatures on push messages, and broadcasts verified updates to all connected clients.
+
+3. **Browser Viewer** (`public/index.html`) — renders the shared markdown with live preview and a CodeMirror editor. Viewers can read freely; editing requires the edit key.
+
+### Security
+
+Livedown uses **Ed25519 asymmetric signing** to protect the sharer's local files from unauthorized edits.
+
+When the sharer runs `livedown share`, the CLI generates an Ed25519 keypair:
+
+- **Edit key** (private key seed, 64 hex chars) — shared only with trusted editors
+- **Public key** — sent to the relay and broadcast to all viewers
+
+Every push message is signed with the private key. Three independent verification points enforce authorization:
+
+| Layer | Has | Verifies | Rejects |
+|-------|-----|----------|---------|
+| **Relay** | Public key | Signature on every push | Unsigned or invalid pushes are never broadcast |
+| **Watcher** | Private key (derives public key) | Signature on incoming updates | Forged updates are never written to disk |
+| **Browser** | Public key (from relay) | Edit key matches public key on entry | Wrong key is rejected before any push |
+
+This means even a compromised relay cannot forge updates that the local watcher would accept — the watcher independently verifies every signature before writing to disk.
+
+### PartyKit and Cloudflare Workers
+
+The relay runs on [PartyKit](https://partykit.io), which deploys to [Cloudflare Workers](https://workers.cloudflare.com). The relay uses the Web Crypto API (`crypto.subtle.verify` with Ed25519) for signature verification — no external dependencies in the deployed bundle.
+
+The CLI and browser use [tweetnacl](https://github.com/nickolay/nickolay/tweetnacl-js) for Ed25519 operations. Both implementations use the same Ed25519 curve and produce compatible signatures.
+
+Rooms are ephemeral — they exist only while connections are active and have no persistent storage. The public key is held in memory for the room's lifetime and must be re-registered on each sharing session.
+
 ## Developer Guide
 
-```bash
-git clone git@github.com:dwmkerr/livedown.git
-cd livedown
-npm install
-npm run build
-npm link
-livedown share ./README.md
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
----
-title: "README"
----
 <p align="center">
   <h2 align="center"><code>📝 livedown</code></h2>
   <h3 align="center">Share a local markdown file and collaborate live in a browser and across machines.</h3>
@@ -9,6 +6,9 @@ title: "README"
     <a href="#how-it-works">How It Works</a> |
     <a href="#commands">Commands</a>
   </p>
+  
+  
+  
   <p align="center">
     <a href="https://github.com/dwmkerr/livedown/actions/workflows/cicd.yaml"><img src="https://github.com/dwmkerr/livedown/actions/workflows/cicd.yaml/badge.svg" alt="cicd"></a>
     <a href="https://www.npmjs.com/package/@dwmkerr/livedown"><img src="https://img.shields.io/npm/v/%40dwmkerr/livedown" alt="npm version"></a>

--- a/docs/superpowers/plans/2026-03-24-edit-token.md
+++ b/docs/superpowers/plans/2026-03-24-edit-token.md
@@ -1,0 +1,645 @@
+# Edit Token Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an "edit token" so the sharer controls who can push changes — viewers can read freely, but editing requires the token.
+
+**Architecture:** The CLI generates a random edit token when sharing and prints it. The sharer's watcher sends a `set-token` message on connect to register the token with the relay. The relay stores it and rejects subsequent `push` messages that don't include a matching `editToken`. The browser viewer starts in read-only mode for protected rooms and prompts for the token when the user clicks an "unlock editing" button.
+
+**Tech Stack:** TypeScript, PartyKit, WebSocket (`ws`), CodeMirror
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/token.ts` | Create | `generateEditToken()` — isolated, testable token generation |
+| `src/token.test.ts` | Create | Tests for token generation |
+| `src/party/livedown.ts` | Modify | Store edit token, validate `push` messages, reject unauthorized edits |
+| `src/party/livedown.test.ts` | Create | Tests for relay auth logic (message validation) |
+| `src/watcher.ts` | Modify | Accept edit token param, send `set-token` on connect, include token in `push` messages, handle `auth-error` |
+| `src/cli.ts` | Modify | Generate token, print it, pass to watcher |
+| `src/cli.test.ts` | Modify | Test that help text shows `--edit-token` option |
+| `public/index.html` | Modify | Start read-only when protected, prompt for edit token, send token in `push` messages |
+
+---
+
+### Task 1: Token Generation Module
+
+**Files:**
+- Create: `src/token.ts`
+- Create: `src/token.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/token.test.ts`:
+
+```typescript
+import { generateEditToken } from "./token";
+
+describe("generateEditToken", () => {
+  it("should return a 32-character hex string", () => {
+    const token = generateEditToken();
+    expect(token).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("should return unique values on each call", () => {
+    const a = generateEditToken();
+    const b = generateEditToken();
+    expect(a).not.toBe(b);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --testPathPattern=token`
+Expected: FAIL — cannot find module `./token`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/token.ts`:
+
+```typescript
+import crypto from "crypto";
+
+export function generateEditToken(): string {
+  return crypto.randomBytes(16).toString("hex");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --testPathPattern=token`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/token.ts src/token.test.ts
+git commit -m "feat: add edit token generation module"
+```
+
+---
+
+### Task 2: Relay Auth Enforcement
+
+**Files:**
+- Modify: `src/party/livedown.ts`
+- Create: `src/party/livedown.test.ts`
+
+**Note:** The `partykit/server` types are only available at runtime, not in jest. We extract the pure `validatePush` function so it can be tested without importing PartyKit types. The test file imports only the pure function.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/party/livedown.test.ts`:
+
+```typescript
+import { validatePush } from "./livedown";
+
+describe("validatePush", () => {
+  it("should accept push when no edit token is set (owner init)", () => {
+    const result = validatePush(undefined, "abc123");
+    expect(result).toBe(true);
+  });
+
+  it("should accept push with matching edit token", () => {
+    const result = validatePush("abc123", "abc123");
+    expect(result).toBe(true);
+  });
+
+  it("should reject push with wrong edit token", () => {
+    const result = validatePush("abc123", "wrong");
+    expect(result).toBe(false);
+  });
+
+  it("should reject push with missing edit token when one is set", () => {
+    const result = validatePush("abc123", undefined);
+    expect(result).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --testPathPattern=livedown`
+Expected: FAIL — `validatePush` is not exported
+
+**Note:** If the test fails because `partykit/server` cannot be resolved in the test environment, add a Jest `moduleNameMapper` to `package.json` or `jest.config.*`:
+
+```json
+"moduleNameMapper": {
+  "^partykit/server$": "<rootDir>/src/__mocks__/partykit-server.ts"
+}
+```
+
+Create `src/__mocks__/partykit-server.ts`:
+
+```typescript
+export {};
+```
+
+- [ ] **Step 3: Extract and export validatePush, update relay logic**
+
+Modify `src/party/livedown.ts` to:
+
+```typescript
+import type * as Party from "partykit/server";
+
+export function validatePush(
+  roomToken: string | undefined,
+  msgToken: string | undefined
+): boolean {
+  if (!roomToken) return true;
+  return !!msgToken && roomToken === msgToken;
+}
+
+export default class LivedownRoom implements Party.Server {
+  latestContent = "";
+  latestMeta: Record<string, string> = {};
+  guestCounter = 0;
+  editToken: string | undefined = undefined;
+
+  constructor(readonly room: Party.Room) {}
+
+  onConnect(conn: Party.Connection) {
+    this.guestCounter++;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (conn as any).guestId = this.guestCounter;
+
+    conn.send(
+      JSON.stringify({
+        type: "init",
+        content: this.latestContent,
+        meta: this.latestMeta,
+        guestId: this.guestCounter,
+        protected: !!this.editToken,
+      })
+    );
+  }
+
+  onMessage(message: string, sender: Party.Connection) {
+    try {
+      const msg = JSON.parse(message);
+
+      // Owner registers the edit token via a dedicated message type
+      if (msg.type === "set-token" && !this.editToken && msg.editToken) {
+        this.editToken = msg.editToken;
+        // Notify all existing connections that the room is now protected
+        this.room.broadcast(
+          JSON.stringify({ type: "protected", protected: true })
+        );
+        return;
+      }
+
+      if (msg.type !== "push") return;
+
+      if (!validatePush(this.editToken, msg.editToken)) {
+        sender.send(JSON.stringify({ type: "auth-error" }));
+        return;
+      }
+
+      this.latestContent = msg.content;
+      this.latestMeta = msg.meta || {};
+
+      this.room.broadcast(
+        JSON.stringify({
+          type: "update",
+          content: msg.content,
+          meta: msg.meta || {},
+        }),
+        [sender.id]
+      );
+    } catch {
+      /* ignore malformed */
+    }
+  }
+}
+```
+
+Key changes:
+- `editToken` field on the room, initially `undefined`
+- Dedicated `set-token` message type — only the first `set-token` is accepted, preventing hijacking by a viewer that connects before the sharer
+- Subsequent pushes must include a matching token or get `auth-error`
+- `init` message includes `protected: true/false` so the viewer knows whether a token is needed
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --testPathPattern=livedown`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/party/livedown.ts src/party/livedown.test.ts
+# If partykit mock was needed:
+git add src/__mocks__/partykit-server.ts
+git commit -m "feat: relay enforces edit token on push messages"
+```
+
+---
+
+### Task 3: Watcher Sends Edit Token
+
+**Files:**
+- Modify: `src/watcher.ts`
+
+- [ ] **Step 1: Add editToken parameter, send set-token on connect, include in pushes, handle auth-error**
+
+Modify `src/watcher.ts`:
+
+1. Change the `startWatcher` function signature to accept `editToken`:
+
+```typescript
+export function startWatcher(
+  filePath: string,
+  doc: string,
+  roomUrl: string,
+  editor: string,
+  editToken: string
+): void {
+```
+
+2. Add `editToken` to the `push` function's JSON payload (inside the object passed to `JSON.stringify`):
+
+```typescript
+    ws.send(
+      JSON.stringify({
+        type: "push",
+        content,
+        editToken,
+        meta: {
+          ...meta,
+          editor,
+          editedAt: new Date().toISOString(),
+          file: doc,
+        },
+      })
+    );
+```
+
+3. In the `ws.on("open", ...)` handler, send `set-token` before the first push:
+
+```typescript
+    ws.on("open", () => {
+      console.log("Connected to room");
+      ws!.send(JSON.stringify({ type: "set-token", editToken }));
+      push(fs.readFileSync(filePath, "utf8"));
+    });
+```
+
+4. In the `ws.on("message", ...)` handler, add handling for `auth-error`:
+
+```typescript
+        if (msg.type === "auth-error") {
+          console.error("Edit token rejected by relay — check your --edit-token value");
+          return;
+        }
+```
+
+- [ ] **Step 2: Run existing tests to verify nothing breaks**
+
+Run: `npm test`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/watcher.ts
+git commit -m "feat: watcher sends set-token and includes edit token in pushes"
+```
+
+---
+
+### Task 4: CLI Generates and Prints Edit Token
+
+**Files:**
+- Modify: `src/cli.ts`
+- Modify: `src/cli.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/cli.test.ts`:
+
+```typescript
+  it("should show edit-token option in share help", () => {
+    const output = execSync(`npx ts-node ${cli} share --help`, {
+      encoding: "utf8",
+    });
+    expect(output).toContain("--edit-token");
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --testPathPattern=cli`
+Expected: FAIL — output does not contain `--edit-token`
+
+- [ ] **Step 3: Update CLI to generate token and pass to watcher**
+
+Modify `src/cli.ts`:
+
+1. Add import at top:
+
+```typescript
+import { generateEditToken } from "./token";
+```
+
+2. Add `--edit-token` option to the `share` command (after the `--doc` option):
+
+```typescript
+  .option("-t, --edit-token <token>", "Edit token (auto-generated if omitted)")
+```
+
+3. Update `startSharing` opts type and body:
+
+```typescript
+function startSharing(
+  file: string,
+  opts: { relay: string; editor: string; doc?: string; editToken?: string }
+): void {
+  const filePath = path.resolve(file);
+  if (!fs.existsSync(filePath)) {
+    console.error(`Error: file not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const filename = path.basename(filePath);
+  const doc = opts.doc || `${shortId()}/${filename}`;
+  const editToken = opts.editToken || generateEditToken();
+  const viewerUrl = buildViewerUrl(opts.relay, doc);
+  const roomUrl = buildRoomUrl(opts.relay, doc);
+
+  console.log(`\n  Watching  ${filePath}`);
+  console.log(
+    `  Join      \x1b[4m\x1b]8;;${viewerUrl}\x07${viewerUrl}\x1b]8;;\x07\x1b[24m`
+  );
+  console.log(`  Edit key  \x1b[33m${editToken}\x1b[0m\n`);
+
+  startWatcher(filePath, doc, roomUrl, opts.editor, editToken);
+}
+```
+
+The no-subcommand fallback path doesn't need changes — `editToken` is optional and will be auto-generated inside `startSharing`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test`
+Expected: All tests PASS (including the new one)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli.ts src/cli.test.ts
+git commit -m "feat: CLI generates and prints edit token"
+```
+
+---
+
+### Task 5: Browser Viewer Edit Token Prompt
+
+**Files:**
+- Modify: `public/index.html`
+
+- [ ] **Step 1: Add edit token UI elements**
+
+Add CSS for the edit token modal (inside the existing `<style>` block, before the closing `</style>`):
+
+```css
+    /* ── Edit-token modal ────────────────────────────────────── */
+    #token-modal {
+      display: none; position: fixed; inset: 0; z-index: 200;
+      background: rgba(0,0,0,.55);
+      justify-content: center; align-items: center;
+    }
+    #token-modal.open { display: flex; }
+    #token-box {
+      background: #1e1e2e; border: 1px solid #313244; border-radius: 8px;
+      padding: 1.5rem; width: 340px; text-align: center;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: #cdd6f4;
+    }
+    #token-box h3 { margin: 0 0 .5rem; font-size: 1.1em; }
+    #token-box p { margin: 0 0 1rem; font-size: .85em; color: #a6adc8; }
+    #token-input {
+      width: 100%; padding: .5rem; border: 1px solid #313244;
+      border-radius: 4px; background: #313244; color: #cdd6f4;
+      font-family: 'SFMono-Regular', Consolas, monospace; font-size: .9em;
+      text-align: center; outline: none;
+    }
+    #token-input:focus { border-color: #89b4fa; }
+    #token-input.error { border-color: #f38ba8; }
+    #token-submit {
+      margin-top: .8rem; padding: .45rem 1.5rem;
+      background: #89b4fa; color: #1e1e2e; border: none; border-radius: 4px;
+      font-weight: 600; cursor: pointer; font-size: .9em;
+    }
+    #token-submit:hover { background: #74c7ec; }
+    #token-cancel {
+      margin-top: .5rem; padding: .3rem 1rem;
+      background: none; color: #6c7086; border: none; cursor: pointer;
+      font-size: .8em;
+    }
+    #token-cancel:hover { color: #cdd6f4; }
+    #token-error-msg {
+      color: #f38ba8; font-size: .8em; margin-top: .5rem;
+      display: none;
+    }
+```
+
+- [ ] **Step 2: Add the modal HTML**
+
+Add this immediately after the `<div id="edits-popover"></div>` line:
+
+```html
+<div id="token-modal">
+  <div id="token-box">
+    <h3>Edit key required</h3>
+    <p>This document is protected. Enter the edit key to make changes.</p>
+    <input id="token-input" type="text" placeholder="Paste edit key" autocomplete="off" spellcheck="false">
+    <div id="token-error-msg">Incorrect edit key. Try again.</div>
+    <br>
+    <button id="token-submit">Unlock editing</button>
+    <br>
+    <button id="token-cancel">View only</button>
+  </div>
+</div>
+```
+
+- [ ] **Step 3: Add edit token logic to the JavaScript**
+
+Add the following variables near the top of the IIFE (after the `myColor` declaration at line ~340):
+
+```javascript
+  let editToken = null;
+  let isProtected = false;
+  let editUnlocked = false;
+  let lastRemoteContent = '';
+```
+
+**Use `readOnly` mode for gating edits** — set CodeMirror to read-only when the room is protected and the token hasn't been entered. This avoids reverting inside the `change` handler which corrupts undo history.
+
+After the CodeMirror instantiation (after `extraKeys: { Tab: false },`), the editor starts writable. We'll set it to read-only once we learn the room is protected (in the `init` handler).
+
+Add the token modal interaction logic (after the `escHtml` function, around line ~445):
+
+```javascript
+  // ── Edit token modal ─────────────────────────────────────────
+  const tokenModal  = document.getElementById('token-modal');
+  const tokenInput  = document.getElementById('token-input');
+  const tokenSubmit = document.getElementById('token-submit');
+  const tokenCancel = document.getElementById('token-cancel');
+  const tokenError  = document.getElementById('token-error-msg');
+
+  function showTokenModal() {
+    tokenModal.classList.add('open');
+    tokenInput.value = '';
+    tokenInput.classList.remove('error');
+    tokenError.style.display = 'none';
+    tokenInput.focus();
+  }
+
+  function hideTokenModal() {
+    tokenModal.classList.remove('open');
+  }
+
+  tokenSubmit.addEventListener('click', function () {
+    var val = tokenInput.value.trim();
+    if (!val) { tokenInput.classList.add('error'); return; }
+    editToken = val;
+    editUnlocked = true;
+    cm.setOption('readOnly', false);
+    hideTokenModal();
+  });
+
+  tokenInput.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') tokenSubmit.click();
+  });
+
+  tokenCancel.addEventListener('click', function () {
+    hideTokenModal();
+  });
+```
+
+Replace the existing `cm.on('change', ...)` handler with:
+
+```javascript
+  cm.on('beforeChange', (instance, changeObj) => {
+    if (changeObj.origin === 'setValue') return;
+    if (isProtected && !editUnlocked) {
+      changeObj.cancel();
+      showTokenModal();
+    }
+  });
+
+  cm.on('change', (instance, changeObj) => {
+    if (changeObj.origin === 'setValue') return;
+    lastLocalEdit = Date.now();
+    clearTimeout(pushTimer);
+    pushTimer = setTimeout(() => push(cm.getValue()), 400);
+  });
+```
+
+Using `beforeChange` to cancel + show modal is cleaner than reverting in `change`. But since we also set `readOnly` when protected, the `beforeChange` handler serves as a belt-and-suspenders fallback.
+
+Update the `push` function to include `editToken`:
+
+```javascript
+  function push(content) {
+    if (!ws || ws.readyState !== 1) return;
+    ws.send(JSON.stringify({
+      type: 'push',
+      content,
+      editToken: editToken,
+      meta: {
+        editor:   myGuestName,
+        editedAt: new Date().toISOString(),
+        file:     docName,
+        color:    myColor,
+      },
+    }));
+    renderPreview(content);
+    recordEdit(myGuestName, new Date().toISOString(), content);
+  }
+```
+
+Update the `ws.onmessage` handler:
+
+In the `msg.type === 'init'` block, add after `setMeta(msg.meta)`:
+```javascript
+        isProtected = !!msg.protected;
+        lastRemoteContent = msg.content || '';
+        if (isProtected && !editUnlocked) {
+          cm.setOption('readOnly', true);
+        }
+```
+
+In the `msg.type === 'update'` block, add:
+```javascript
+        lastRemoteContent = msg.content || '';
+```
+
+Add new handlers after the `update` block (before the closing `};` of `ws.onmessage`):
+
+```javascript
+      if (msg.type === 'auth-error') {
+        editUnlocked = false;
+        editToken = null;
+        cm.setOption('readOnly', true);
+        tokenInput.classList.add('error');
+        tokenError.style.display = 'block';
+        showTokenModal();
+        return;
+      }
+
+      if (msg.type === 'protected') {
+        isProtected = !!msg.protected;
+        if (isProtected && !editUnlocked) {
+          cm.setOption('readOnly', true);
+        }
+      }
+```
+
+- [ ] **Step 4: Manually verify in browser** (cannot be unit tested)
+
+1. Run `npx ts-node src/cli.ts share test.md` — note the edit key printed
+2. Open the viewer URL in a browser
+3. Try to type — editor should be read-only, modal should appear
+4. Enter wrong token — relay sends `auth-error`, modal shows error state
+5. Enter correct token — editor becomes writable, editing works
+6. Open a second browser tab — should start read-only until token entered
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/index.html
+git commit -m "feat: browser viewer prompts for edit token"
+```
+
+---
+
+### Task 6: Final Integration Verification
+
+- [ ] **Step 1: Run all tests**
+
+Run: `npm test`
+Expected: All tests PASS
+
+- [ ] **Step 2: Run linter**
+
+Run: `npm run lint`
+Expected: No errors (fix any that appear)
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: Clean build with no errors
+
+- [ ] **Step 4: Commit any fixes**
+
+If lint or build required changes:
+```bash
+git add -A
+git commit -m "fix: lint and build fixes for edit token feature"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
         "chokidar": "^4.0.0",
+        "clipboardy": "^5.3.1",
         "commander": "^11.1.0",
         "gray-matter": "^4.0.3",
         "open": "^11.0.0",
@@ -3275,12 +3276,30 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -4480,16 +4499,78 @@
         "node": ">= 12"
       }
     },
-    "node_modules/clipboardy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
-      "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
-      "dev": true,
+    "node_modules/clipboard-image": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clipboard-image/-/clipboard-image-0.1.0.tgz",
+      "integrity": "sha512-SWk7FgaXLNFld19peQ/rTe0n97lwR1WbkqxV6JKCAOh7U52AKV/PeMFCyt/8IhBdqyDA8rdyewQMKZqvWT5Akg==",
       "license": "MIT",
       "dependencies": {
-        "execa": "^8.0.1",
+        "run-jxa": "^3.0.0"
+      },
+      "bin": {
+        "clipboard-image": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-5.3.1.tgz",
+      "integrity": "sha512-fPWgBqpp9ctiOQCkE5yjYGzv11ZU55g6ahEgr3COiio6dXdt1mbchCPXQrSR2Y9sZqfi8L7QD3+UosgXVIuPdg==",
+      "license": "MIT",
+      "dependencies": {
+        "clipboard-image": "^0.1.0",
+        "execa": "^9.6.1",
+        "is-wayland": "^0.1.0",
         "is-wsl": "^3.1.0",
-        "is64bit": "^2.0.0"
+        "is64bit": "^2.0.0",
+        "powershell-utils": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/clipboardy/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
       },
       "engines": {
         "node": ">=18"
@@ -4498,106 +4579,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/clipboardy/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/clipboardy/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/clipboardy/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/clipboardy/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/clipboardy/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/onetime": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "license": "MIT",
       "dependencies": {
-        "mimic-fn": "^4.0.0"
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4607,10 +4620,21 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/powershell-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4620,7 +4644,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -4630,13 +4653,12 @@
       }
     },
     "node_modules/clipboardy/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4809,7 +4831,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4818,6 +4839,33 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/data-uri-to-buffer": {
@@ -5337,7 +5385,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -5469,6 +5516,21 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5632,7 +5694,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5812,7 +5873,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -6040,14 +6100,49 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wayland": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-wayland/-/is-wayland-0.1.0.tgz",
+      "integrity": "sha512-QkbMsWkIfkrzOPxenwye0h56iAXirZYHG9eHVPb22fO9y+wPbaX/CHacOWBa/I++4ohTcByimhM1/nyCsH8KNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6072,7 +6167,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
       "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "system-architecture": "^0.1.0"
@@ -6088,7 +6182,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -8636,6 +8729,21 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/macos-version": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/macos-version/-/macos-version-6.0.0.tgz",
+      "integrity": "sha512-O2S8voA+pMfCHhBn/TIYDXzJ1qNHpPDU32oFxglKnVdJABiYYITt45oLkV9yhwA3E2FDwn3tQqUFrTsr1p3sBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -8673,7 +8781,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -8694,7 +8801,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8890,7 +8996,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -8920,7 +9025,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -9051,6 +9155,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/partykit": {
       "version": "0.0.115",
       "resolved": "https://registry.npmjs.org/partykit/-/partykit-0.0.115.tgz",
@@ -9071,6 +9187,168 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"
+      }
+    },
+    "node_modules/partykit/node_modules/clipboardy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
+      "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^8.0.1",
+        "is-wsl": "^3.1.0",
+        "is64bit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/partykit/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/partykit/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/partykit/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/partykit/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/partykit/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/partykit/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/partykit/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/partykit/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/partykit/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/partykit/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -9097,7 +9375,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9332,6 +9609,21 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/printable-characters": {
       "version": "1.0.42",
       "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
@@ -9451,6 +9743,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/run-jxa": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-jxa/-/run-jxa-3.0.0.tgz",
+      "integrity": "sha512-4f2CrY7H+sXkKXJn/cE6qRA3z+NMVO7zvlZ/nUV0e62yWftpiLAfw5eV9ZdomzWd2TXWwEIiGjAT57+lWIzzvA==",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "macos-version": "^6.0.0",
+        "subsume": "^4.0.0",
+        "type-fest": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-jxa/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -9474,7 +9796,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9487,7 +9808,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9500,7 +9820,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9510,7 +9829,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/slash": {
@@ -9759,7 +10077,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9773,6 +10090,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/subsume": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/subsume/-/subsume-4.0.0.tgz",
+      "integrity": "sha512-BWnYJElmHbYZ/zKevy+TG+SsyoFCmRPDHJbR1MzLxkPOv1Jp/4hGhVUtP98s+wZBsBsHwCXvPTP0x287/WMjGg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/subsume/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9811,7 +10156,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
       "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10671,6 +11015,33 @@
         "ufo": "^1.5.4"
       }
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -10783,7 +11154,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11108,6 +11478,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
+        "@noble/curves": "^2.0.1",
         "chokidar": "^4.0.0",
         "clipboardy": "^5.3.1",
         "commander": "^11.1.0",
@@ -3251,6 +3252,33 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "commander": "^11.1.0",
         "gray-matter": "^4.0.3",
         "open": "^11.0.0",
+        "tweetnacl": "^1.0.3",
         "ws": "^8.19.0"
       },
       "bin": {
@@ -10885,6 +10886,12 @@
         "@esbuild/win32-ia32": "0.27.4",
         "@esbuild/win32-x64": "0.27.4"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
+    "@noble/curves": "^2.0.1",
     "chokidar": "^4.0.0",
     "clipboardy": "^5.3.1",
     "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dwmkerr/livedown",
   "version": "0.1.1",
-  "description": "Edit markdown locally, share it live in a browser.",
+  "description": "Share a local markdown file and collaborate live in a browser and across machines.",
   "type": "commonjs",
   "main": "./dist/cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
     "chokidar": "^4.0.0",
+    "clipboardy": "^5.3.1",
     "commander": "^11.1.0",
     "gray-matter": "^4.0.3",
     "open": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "commander": "^11.1.0",
     "gray-matter": "^4.0.3",
     "open": "^11.0.0",
+    "tweetnacl": "^1.0.3",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/partykit.json
+++ b/partykit.json
@@ -1,6 +1,6 @@
 {
   "name": "livedown",
   "main": "src/party/livedown.ts",
-  "compatibilityDate": "2024-01-01",
+  "compatibilityDate": "2025-01-01",
   "serve": "public"
 }

--- a/public/index.html
+++ b/public/index.html
@@ -209,6 +209,46 @@
       color: #f38ba8; font-size: .9em; line-height: 1.5;
     }
     #landing-error.visible { display: block; }
+
+    /* ── Edit-token modal ────────────────────────────────────── */
+    #token-modal {
+      display: none; position: fixed; inset: 0; z-index: 200;
+      background: rgba(0,0,0,.55);
+      justify-content: center; align-items: center;
+    }
+    #token-modal.open { display: flex; }
+    #token-box {
+      background: #1e1e2e; border: 1px solid #313244; border-radius: 8px;
+      padding: 1.5rem; width: 340px; text-align: center;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: #cdd6f4;
+    }
+    #token-box h3 { margin: 0 0 .5rem; font-size: 1.1em; }
+    #token-box p { margin: 0 0 1rem; font-size: .85em; color: #a6adc8; }
+    #token-input {
+      width: 100%; padding: .5rem; border: 1px solid #313244;
+      border-radius: 4px; background: #313244; color: #cdd6f4;
+      font-family: 'SFMono-Regular', Consolas, monospace; font-size: .9em;
+      text-align: center; outline: none;
+    }
+    #token-input:focus { border-color: #89b4fa; }
+    #token-input.error { border-color: #f38ba8; }
+    #token-submit {
+      margin-top: .8rem; padding: .45rem 1.5rem;
+      background: #89b4fa; color: #1e1e2e; border: none; border-radius: 4px;
+      font-weight: 600; cursor: pointer; font-size: .9em;
+    }
+    #token-submit:hover { background: #74c7ec; }
+    #token-cancel {
+      margin-top: .5rem; padding: .3rem 1rem;
+      background: none; color: #6c7086; border: none; cursor: pointer;
+      font-size: .8em;
+    }
+    #token-cancel:hover { color: #cdd6f4; }
+    #token-error-msg {
+      color: #f38ba8; font-size: .8em; margin-top: .5rem;
+      display: none;
+    }
   </style>
 </head>
 <body>
@@ -275,6 +315,19 @@
 
 <div id="edits-popover"></div>
 
+<div id="token-modal">
+  <div id="token-box">
+    <h3>Edit key required</h3>
+    <p>This document is protected. Enter the edit key to make changes.</p>
+    <input id="token-input" type="text" placeholder="Paste edit key" autocomplete="off" spellcheck="false">
+    <div id="token-error-msg">Incorrect edit key. Try again.</div>
+    <br>
+    <button id="token-submit">Unlock editing</button>
+    <br>
+    <button id="token-cancel">View only</button>
+  </div>
+</div>
+
 <div id="panes">
   <div id="pane-source">
     <div id="loading" class="active">
@@ -338,6 +391,10 @@
   let myGuestId   = null;
   let myGuestName = null;
   let myColor     = null;
+  let editToken = null;
+  let isProtected = false;
+  let editUnlocked = false;
+  let lastRemoteContent = '';
 
   function setProfile(guestId) {
     myGuestId   = guestId;
@@ -364,10 +421,17 @@
   let lastLocalEdit = 0;
   let pushTimer     = null;
 
+  cm.on('beforeChange', (instance, changeObj) => {
+    if (changeObj.origin === 'setValue') return;
+    if (isProtected && !editUnlocked) {
+      changeObj.cancel();
+      showTokenModal();
+    }
+  });
+
   cm.on('change', (instance, changeObj) => {
-    if (changeObj.origin === 'setValue') return; // ignore programmatic updates
+    if (changeObj.origin === 'setValue') return;
     lastLocalEdit = Date.now();
-    // Debounce: push 400ms after last keystroke
     clearTimeout(pushTimer);
     pushTimer = setTimeout(() => push(cm.getValue()), 400);
   });
@@ -444,6 +508,42 @@
     return d.innerHTML;
   }
 
+  // ── Edit token modal ─────────────────────────────────────────
+  const tokenModal  = document.getElementById('token-modal');
+  const tokenInput  = document.getElementById('token-input');
+  const tokenSubmit = document.getElementById('token-submit');
+  const tokenCancel = document.getElementById('token-cancel');
+  const tokenError  = document.getElementById('token-error-msg');
+
+  function showTokenModal() {
+    tokenModal.classList.add('open');
+    tokenInput.value = '';
+    tokenInput.classList.remove('error');
+    tokenError.style.display = 'none';
+    tokenInput.focus();
+  }
+
+  function hideTokenModal() {
+    tokenModal.classList.remove('open');
+  }
+
+  tokenSubmit.addEventListener('click', function () {
+    var val = tokenInput.value.trim();
+    if (!val) { tokenInput.classList.add('error'); return; }
+    editToken = val;
+    editUnlocked = true;
+    cm.setOption('readOnly', false);
+    hideTokenModal();
+  });
+
+  tokenInput.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') tokenSubmit.click();
+  });
+
+  tokenCancel.addEventListener('click', function () {
+    hideTokenModal();
+  });
+
   editsSeg.addEventListener('click', function (e) {
     e.stopPropagation();
     editsPopover.classList.toggle('open');
@@ -482,6 +582,7 @@
     ws.send(JSON.stringify({
       type: 'push',
       content,
+      editToken: editToken,
       meta: {
         editor:   myGuestName,
         editedAt: new Date().toISOString(),
@@ -515,6 +616,11 @@
           renderPreview(msg.content);
         }
         setMeta(msg.meta);
+        isProtected = !!msg.protected;
+        lastRemoteContent = msg.content || '';
+        if (isProtected && !editUnlocked) {
+          cm.setOption('readOnly', true);
+        }
         setLastEdit(msg.meta?.editor, msg.meta?.editedAt);
         if (msg.meta?.editor) recordEdit(msg.meta.editor, msg.meta.editedAt, msg.content);
         return;
@@ -522,6 +628,7 @@
 
       if (msg.type === 'update') {
         gotContent = true;
+        lastRemoteContent = msg.content || '';
         setMeta(msg.meta);
         setLastEdit(msg.meta?.editor, msg.meta?.editedAt);
         recordEdit(msg.meta?.editor, msg.meta?.editedAt, msg.content);
@@ -532,6 +639,23 @@
           cm.setValue(msg.content || '');
         } else {
           flashRemoteEdit();
+        }
+      }
+
+      if (msg.type === 'auth-error') {
+        editUnlocked = false;
+        editToken = null;
+        cm.setOption('readOnly', true);
+        tokenInput.classList.add('error');
+        tokenError.style.display = 'block';
+        showTokenModal();
+        return;
+      }
+
+      if (msg.type === 'protected') {
+        isProtected = !!msg.protected;
+        if (isProtected && !editUnlocked) {
+          cm.setOption('readOnly', true);
         }
       }
     };

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>livedown</title>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/tweetnacl@1.0.3/nacl-fast.min.js"></script>
   <link  rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.17/codemirror.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.17/codemirror.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.17/mode/markdown/markdown.min.js"></script>
@@ -400,9 +401,38 @@
   let myGuestId   = null;
   let myGuestName = null;
   let myColor     = null;
-  let editToken = null;
+  let editKey = null;      // private key seed (hex) — entered by user
+  let secretKey = null;    // full 64-byte nacl secret key
+  let roomPublicKey = null; // public key from relay (hex)
   let isProtected = false;
   let editUnlocked = false;
+
+  // Hex conversion helpers for tweetnacl
+  function hexToBytes(hex) {
+    var bytes = new Uint8Array(hex.length / 2);
+    for (var i = 0; i < hex.length; i += 2) {
+      bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+    }
+    return bytes;
+  }
+  function bytesToHex(bytes) {
+    return Array.from(bytes).map(function(b) {
+      return b.toString(16).padStart(2, '0');
+    }).join('');
+  }
+  function signContent(content, sk) {
+    var msg = new TextEncoder().encode(content);
+    var sig = nacl.sign.detached(msg, sk);
+    return bytesToHex(sig);
+  }
+  function verifyContent(content, sigHex, pubHex) {
+    try {
+      var msg = new TextEncoder().encode(content);
+      var sig = hexToBytes(sigHex);
+      var pub = hexToBytes(pubHex);
+      return nacl.sign.detached.verify(msg, sig, pub);
+    } catch (e) { return false; }
+  }
 
 
   function setProfile(guestId) {
@@ -560,10 +590,25 @@
   tokenSubmit.addEventListener('click', function () {
     var val = tokenInput.value.trim();
     if (!val) { tokenInput.classList.add('error'); return; }
-    editToken = val;
-    editUnlocked = true;
-    updateProfileAccess();
-    hideTokenModal();
+    try {
+      var seed = hexToBytes(val);
+      if (seed.length !== 32) throw new Error('bad length');
+      var kp = nacl.sign.keyPair.fromSeed(seed);
+      // Verify it matches the room's public key
+      if (roomPublicKey && bytesToHex(kp.publicKey) !== roomPublicKey) {
+        tokenInput.classList.add('error');
+        tokenError.style.display = 'block';
+        return;
+      }
+      editKey = val;
+      secretKey = kp.secretKey;
+      editUnlocked = true;
+      updateProfileAccess();
+      hideTokenModal();
+    } catch (e) {
+      tokenInput.classList.add('error');
+      tokenError.style.display = 'block';
+    }
   });
 
   tokenInput.addEventListener('keydown', function (e) {
@@ -609,10 +654,11 @@
 
   function push(content) {
     if (!ws || ws.readyState !== 1) return;
+    var signature = secretKey ? signContent(content, secretKey) : null;
     ws.send(JSON.stringify({
       type: 'push',
       content,
-      editToken: editToken,
+      signature: signature,
       meta: {
         editor:   myGuestName,
         editedAt: new Date().toISOString(),
@@ -647,6 +693,7 @@
         }
         setMeta(msg.meta);
         isProtected = !!msg.protected;
+        if (msg.publicKey) roomPublicKey = msg.publicKey;
         updateProfileAccess();
         setLastEdit(msg.meta?.editor, msg.meta?.editedAt);
         if (msg.meta?.editor) recordEdit(msg.meta.editor, msg.meta.editedAt, msg.content);
@@ -671,7 +718,8 @@
 
       if (msg.type === 'auth-error') {
         editUnlocked = false;
-        editToken = null;
+        editKey = null;
+        secretKey = null;
         updateProfileAccess();
         showTokenModal();
         tokenInput.classList.add('error');
@@ -681,6 +729,7 @@
 
       if (msg.type === 'protected') {
         isProtected = !!msg.protected;
+        if (msg.publicKey) roomPublicKey = msg.publicKey;
         updateProfileAccess();
       }
     };

--- a/public/index.html
+++ b/public/index.html
@@ -100,6 +100,14 @@
       flex-shrink: 0;
     }
     #profile-name { font-weight: 500; }
+    #profile-access {
+      font-size: 10px; color: #f38ba8; font-weight: 500;
+    }
+    #profile-access a {
+      color: #89b4fa; text-decoration: none; cursor: pointer;
+    }
+    #profile-access a:hover { text-decoration: underline; }
+    #profile-access.editor { color: #a6e3a1; }
 
     /* ── Split panes ────────────────────────────────────────── */
     #panes { display: flex; height: calc(100vh - 32px); }
@@ -306,6 +314,7 @@
   <div id="profile">
     <div id="profile-avatar">?</div>
     <span id="profile-name">connecting…</span>
+    <span id="profile-access"></span>
   </div>
   <div class="sb-seg" id="sb-status">
     <div id="sb-dot"></div>
@@ -405,6 +414,27 @@
     av.textContent  = 'G' + guestId;
     av.style.background = myColor;
     nm.textContent  = myGuestName;
+  }
+
+  function updateProfileAccess() {
+    var el = document.getElementById('profile-access');
+    if (!isProtected) {
+      el.textContent = '';
+      el.className = '';
+      return;
+    }
+    if (editUnlocked) {
+      el.textContent = '(Editor)';
+      el.className = 'editor';
+      el.onclick = null;
+      el.innerHTML = '<span style="color:#a6e3a1">(Editor)</span>';
+    } else {
+      el.innerHTML = '(Read Only \u2014 <a id="profile-unlock">Enter Edit Key</a>)';
+      document.getElementById('profile-unlock').addEventListener('click', function (e) {
+        e.preventDefault();
+        showTokenModal();
+      });
+    }
   }
 
   // ── CodeMirror ───────────────────────────────────────────────
@@ -532,7 +562,7 @@
     if (!val) { tokenInput.classList.add('error'); return; }
     editToken = val;
     editUnlocked = true;
-    cm.setOption('readOnly', false);
+    updateProfileAccess();
     hideTokenModal();
   });
 
@@ -617,10 +647,7 @@
         }
         setMeta(msg.meta);
         isProtected = !!msg.protected;
-
-        if (isProtected && !editUnlocked) {
-          cm.setOption('readOnly', true);
-        }
+        updateProfileAccess();
         setLastEdit(msg.meta?.editor, msg.meta?.editedAt);
         if (msg.meta?.editor) recordEdit(msg.meta.editor, msg.meta.editedAt, msg.content);
         return;
@@ -645,7 +672,7 @@
       if (msg.type === 'auth-error') {
         editUnlocked = false;
         editToken = null;
-        cm.setOption('readOnly', true);
+        updateProfileAccess();
         showTokenModal();
         tokenInput.classList.add('error');
         tokenError.style.display = 'block';
@@ -654,9 +681,7 @@
 
       if (msg.type === 'protected') {
         isProtected = !!msg.protected;
-        if (isProtected && !editUnlocked) {
-          cm.setOption('readOnly', true);
-        }
+        updateProfileAccess();
       }
     };
 

--- a/public/index.html
+++ b/public/index.html
@@ -277,6 +277,10 @@
 </div>
 
 <div id="statusbar">
+  <a class="sb-seg" href="https://github.com/dwmkerr/livedown" target="_blank" style="text-decoration:none;gap:4px">
+    <span style="font-weight:700;color:#89b4fa">livedown</span>
+    <span id="sb-version" style="color:#6c7086;font-size:10px"></span>
+  </a>
   <div class="sb-seg">
     <span style="opacity:.5">📄</span>
     <span id="sb-file">—</span>
@@ -354,6 +358,15 @@
 
 <script>
 (function () {
+  // Fetch version from npm registry
+  fetch('https://registry.npmjs.org/@dwmkerr/livedown/latest')
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      var el = document.getElementById('sb-version');
+      if (el && d.version) el.textContent = 'v' + d.version;
+    })
+    .catch(function() {});
+
   function showLanding(errorMsg) {
     document.getElementById('landing').style.display = 'block';
     document.getElementById('statusbar').style.display = 'none';

--- a/public/index.html
+++ b/public/index.html
@@ -394,7 +394,7 @@
   let editToken = null;
   let isProtected = false;
   let editUnlocked = false;
-  let lastRemoteContent = '';
+
 
   function setProfile(guestId) {
     myGuestId   = guestId;
@@ -617,7 +617,7 @@
         }
         setMeta(msg.meta);
         isProtected = !!msg.protected;
-        lastRemoteContent = msg.content || '';
+
         if (isProtected && !editUnlocked) {
           cm.setOption('readOnly', true);
         }
@@ -628,7 +628,7 @@
 
       if (msg.type === 'update') {
         gotContent = true;
-        lastRemoteContent = msg.content || '';
+
         setMeta(msg.meta);
         setLastEdit(msg.meta?.editor, msg.meta?.editedAt);
         recordEdit(msg.meta?.editor, msg.meta?.editedAt, msg.content);
@@ -646,9 +646,9 @@
         editUnlocked = false;
         editToken = null;
         cm.setOption('readOnly', true);
+        showTokenModal();
         tokenInput.classList.add('error');
         tokenError.style.display = 'block';
-        showTokenModal();
         return;
       }
 

--- a/public/index.html
+++ b/public/index.html
@@ -257,7 +257,7 @@
   <div id="landing-inner">
     <div id="landing-error"></div>
     <h1>livedown</h1>
-    <p>Edit markdown locally, share it live in a browser.</p>
+    <p>Share a local markdown file and collaborate live in a browser and across machines.</p>
     <pre><code>npx @dwmkerr/livedown share ./your-file.md</code></pre>
     <p>Your file will be live at <code>livedown.dwmkerr.partykit.dev/#...</code></p>
     <p class="dim" style="margin-top:2em">

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -19,4 +19,11 @@ describe("cli", () => {
     });
     expect(output.trim()).toMatch(/^\d+\.\d+\.\d+$/);
   });
+
+  it("should show edit-token option in share help", () => {
+    const output = execSync(`npx ts-node ${cli} share --help`, {
+      encoding: "utf8",
+    });
+    expect(output).toContain("--edit-token");
+  });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -20,10 +20,10 @@ describe("cli", () => {
     expect(output.trim()).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
-  it("should show edit-token option in share help", () => {
+  it("should show edit-key option in share help", () => {
     const output = execSync(`npx ts-node ${cli} share --help`, {
       encoding: "utf8",
     });
-    expect(output).toContain("--edit-token");
+    expect(output).toContain("--edit-key");
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,6 +65,29 @@ async function startSharing(
   }
 
   startWatcher(filePath, doc, roomUrl, opts.editor, editToken);
+
+  if (process.stdin.isTTY) {
+    const dim = "\x1b[2m";
+    const reset = "\x1b[0m";
+    console.log(`${dim}  t copy edit key  q quit${reset}\n`);
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.on("data", async (key: Buffer) => {
+      const ch = key.toString();
+      if (ch === "q" || ch === "\u0003") {
+        process.exit(0);
+      }
+      if (ch === "t") {
+        try {
+          const { default: clipboardy } = await import("clipboardy");
+          await clipboardy.write(editToken);
+          console.log("  \x1b[32m✓ Edit key copied to clipboard\x1b[0m");
+        } catch {
+          console.log("  \x1b[31m✗ Could not copy to clipboard\x1b[0m");
+        }
+      }
+    });
+  }
 }
 
 const defaultRelay = process.env.PARTYKIT_HOST || DEFAULT_RELAY;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,9 +67,6 @@ async function startSharing(
   startWatcher(filePath, doc, roomUrl, opts.editor, editToken);
 
   if (process.stdin.isTTY) {
-    const dim = "\x1b[2m";
-    const reset = "\x1b[0m";
-    console.log(`${dim}  t copy edit key  q quit${reset}\n`);
     process.stdin.setRawMode(true);
     process.stdin.resume();
     process.stdin.on("data", async (key: Buffer) => {
@@ -81,9 +78,15 @@ async function startSharing(
         try {
           const { default: clipboardy } = await import("clipboardy");
           await clipboardy.write(editToken);
-          console.log("  \x1b[32m✓ Edit key copied to clipboard\x1b[0m");
+          console.log(
+            "\x1b[2K\r  \x1b[32m✓ Edit key copied to clipboard\x1b[0m"
+          );
+          process.stdout.write("\x1b[2m  t copy edit key  q quit\x1b[0m");
         } catch {
-          console.log("  \x1b[31m✗ Could not copy to clipboard\x1b[0m");
+          console.log(
+            "\x1b[2K\r  \x1b[31m✗ Could not copy to clipboard\x1b[0m"
+          );
+          process.stdout.write("\x1b[2m  t copy edit key  q quit\x1b[0m");
         }
       }
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import os from "os";
 import path from "path";
 import { Command } from "commander";
 import { startWatcher } from "./watcher";
-import { generateEditToken } from "./token";
+import { generateEditKeyPair, publicKeyFromEditKey } from "./token";
 
 const pkg = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")
@@ -29,7 +29,7 @@ function buildRoomUrl(relay: string, doc: string): string {
 
 async function startSharing(
   file: string,
-  opts: { relay: string; editor: string; doc?: string; editToken?: string }
+  opts: { relay: string; editor: string; doc?: string; editKey?: string }
 ): Promise<void> {
   const filePath = path.resolve(file);
   if (!fs.existsSync(filePath)) {
@@ -39,7 +39,16 @@ async function startSharing(
 
   const filename = path.basename(filePath);
   const doc = opts.doc || `${shortId()}/${filename}`;
-  const editToken = opts.editToken || generateEditToken();
+  let editKey: string;
+  let publicKey: string;
+  if (opts.editKey) {
+    editKey = opts.editKey;
+    publicKey = publicKeyFromEditKey(editKey);
+  } else {
+    const kp = generateEditKeyPair();
+    editKey = kp.editKey;
+    publicKey = kp.publicKey;
+  }
   const viewerUrl = buildViewerUrl(opts.relay, doc);
   const roomUrl = buildRoomUrl(opts.relay, doc);
 
@@ -47,7 +56,7 @@ async function startSharing(
   console.log(
     `  Join      \x1b[4m\x1b]8;;${viewerUrl}\x07${viewerUrl}\x1b]8;;\x07\x1b[24m`
   );
-  console.log(`  Edit key  \x1b[33m${editToken}\x1b[0m\n`);
+  console.log(`  Edit key  \x1b[33m${editKey}\x1b[0m\n`);
 
   const { confirm } = await import("@inquirer/prompts");
   const shouldCopy = await confirm({
@@ -57,14 +66,14 @@ async function startSharing(
   if (shouldCopy) {
     try {
       const { default: clipboardy } = await import("clipboardy");
-      await clipboardy.write(editToken);
+      await clipboardy.write(editKey);
       console.log("  \x1b[32m✓ Edit key copied to clipboard\x1b[0m\n");
     } catch {
       console.log("  \x1b[31m✗ Could not copy to clipboard\x1b[0m\n");
     }
   }
 
-  startWatcher(filePath, doc, roomUrl, opts.editor, editToken);
+  startWatcher(filePath, doc, roomUrl, opts.editor, editKey, publicKey);
 
   if (process.stdin.isTTY) {
     process.stdin.setRawMode(true);
@@ -77,7 +86,7 @@ async function startSharing(
       if (ch === "t") {
         try {
           const { default: clipboardy } = await import("clipboardy");
-          await clipboardy.write(editToken);
+          await clipboardy.write(editKey);
           console.log(
             "\x1b[2K\r  \x1b[32m✓ Edit key copied to clipboard\x1b[0m"
           );
@@ -113,7 +122,7 @@ program
   .option("-r, --relay <host>", "Relay host", defaultRelay)
   .option("-e, --editor <name>", "Your name shown to viewers", defaultEditor)
   .option("-d, --doc <name>", "Document name (defaults to filename)")
-  .option("-t, --edit-token <token>", "Edit token (auto-generated if omitted)")
+  .option("-k, --edit-key <key>", "Edit key (auto-generated if omitted)")
   .action(startSharing);
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,10 +27,10 @@ function buildRoomUrl(relay: string, doc: string): string {
   return `${proto}://${relay}/parties/main/${encodeURIComponent(doc)}`;
 }
 
-function startSharing(
+async function startSharing(
   file: string,
   opts: { relay: string; editor: string; doc?: string; editToken?: string }
-): void {
+): Promise<void> {
   const filePath = path.resolve(file);
   if (!fs.existsSync(filePath)) {
     console.error(`Error: file not found: ${filePath}`);
@@ -48,6 +48,21 @@ function startSharing(
     `  Join      \x1b[4m\x1b]8;;${viewerUrl}\x07${viewerUrl}\x1b]8;;\x07\x1b[24m`
   );
   console.log(`  Edit key  \x1b[33m${editToken}\x1b[0m\n`);
+
+  const { confirm } = await import("@inquirer/prompts");
+  const shouldCopy = await confirm({
+    message: "Copy edit key to clipboard?",
+    default: true,
+  });
+  if (shouldCopy) {
+    try {
+      const { default: clipboardy } = await import("clipboardy");
+      await clipboardy.write(editToken);
+      console.log("  \x1b[32m✓ Edit key copied to clipboard\x1b[0m\n");
+    } catch {
+      console.log("  \x1b[31m✗ Could not copy to clipboard\x1b[0m\n");
+    }
+  }
 
   startWatcher(filePath, doc, roomUrl, opts.editor, editToken);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,9 @@ const program = new Command();
 
 program
   .name("livedown")
-  .description("Edit markdown locally, share it live in a browser.")
+  .description(
+    "Share a local markdown file and collaborate live in a browser and across machines."
+  )
   .version(pkg.version);
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import os from "os";
 import path from "path";
 import { Command } from "commander";
 import { startWatcher } from "./watcher";
+import { generateEditToken } from "./token";
 
 const pkg = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")
@@ -38,15 +39,17 @@ function startSharing(
 
   const filename = path.basename(filePath);
   const doc = opts.doc || `${shortId()}/${filename}`;
+  const editToken = opts.editToken || generateEditToken();
   const viewerUrl = buildViewerUrl(opts.relay, doc);
   const roomUrl = buildRoomUrl(opts.relay, doc);
 
   console.log(`\n  Watching  ${filePath}`);
   console.log(
-    `  Join      \x1b[4m\x1b]8;;${viewerUrl}\x07${viewerUrl}\x1b]8;;\x07\x1b[24m\n`
+    `  Join      \x1b[4m\x1b]8;;${viewerUrl}\x07${viewerUrl}\x1b]8;;\x07\x1b[24m`
   );
+  console.log(`  Edit key  \x1b[33m${editToken}\x1b[0m\n`);
 
-  startWatcher(filePath, doc, roomUrl, opts.editor, opts.editToken ?? "");
+  startWatcher(filePath, doc, roomUrl, opts.editor, editToken);
 }
 
 const defaultRelay = process.env.PARTYKIT_HOST || DEFAULT_RELAY;
@@ -67,6 +70,7 @@ program
   .option("-r, --relay <host>", "Relay host", defaultRelay)
   .option("-e, --editor <name>", "Your name shown to viewers", defaultEditor)
   .option("-d, --doc <name>", "Document name (defaults to filename)")
+  .option("-t, --edit-token <token>", "Edit token (auto-generated if omitted)")
   .action(startSharing);
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@ function buildRoomUrl(relay: string, doc: string): string {
 
 function startSharing(
   file: string,
-  opts: { relay: string; editor: string; doc?: string }
+  opts: { relay: string; editor: string; doc?: string; editToken?: string }
 ): void {
   const filePath = path.resolve(file);
   if (!fs.existsSync(filePath)) {
@@ -46,7 +46,7 @@ function startSharing(
     `  Join      \x1b[4m\x1b]8;;${viewerUrl}\x07${viewerUrl}\x1b]8;;\x07\x1b[24m\n`
   );
 
-  startWatcher(filePath, doc, roomUrl, opts.editor);
+  startWatcher(filePath, doc, roomUrl, opts.editor, opts.editToken ?? "");
 }
 
 const defaultRelay = process.env.PARTYKIT_HOST || DEFAULT_RELAY;

--- a/src/party/livedown.test.ts
+++ b/src/party/livedown.test.ts
@@ -1,8 +1,9 @@
 import { generateEditKeyPair, signContent, verifySignature } from "../token";
 
-// Relay uses Web Crypto API (not available in Jest/Node).
-// Test the signing/verification logic via the token module instead,
-// which uses tweetnacl (same Ed25519 algorithm, compatible signatures).
+// The relay uses @noble/curves for Ed25519 verification, which can't be
+// imported in Jest due to ESM/BigInt transpilation issues. Instead we test
+// the cross-library compatibility via tweetnacl (token.ts), since both
+// implement standard Ed25519 (RFC 8032) and produce identical signatures.
 describe("Ed25519 signature verification", () => {
   it("should verify a valid signature", () => {
     const kp = generateEditKeyPair();

--- a/src/party/livedown.test.ts
+++ b/src/party/livedown.test.ts
@@ -1,0 +1,23 @@
+import { validatePush } from "./livedown";
+
+describe("validatePush", () => {
+  it("should accept push when no edit token is set (owner init)", () => {
+    const result = validatePush(undefined, "abc123");
+    expect(result).toBe(true);
+  });
+
+  it("should accept push with matching edit token", () => {
+    const result = validatePush("abc123", "abc123");
+    expect(result).toBe(true);
+  });
+
+  it("should reject push with wrong edit token", () => {
+    const result = validatePush("abc123", "wrong");
+    expect(result).toBe(false);
+  });
+
+  it("should reject push with missing edit token when one is set", () => {
+    const result = validatePush("abc123", undefined);
+    expect(result).toBe(false);
+  });
+});

--- a/src/party/livedown.test.ts
+++ b/src/party/livedown.test.ts
@@ -1,23 +1,30 @@
-import { validatePush } from "./livedown";
+import { generateEditKeyPair, signContent, verifySignature } from "../token";
 
-describe("validatePush", () => {
-  it("should accept push when no edit token is set (owner init)", () => {
-    const result = validatePush(undefined, "abc123");
-    expect(result).toBe(true);
+// Relay uses Web Crypto API (not available in Jest/Node).
+// Test the signing/verification logic via the token module instead,
+// which uses tweetnacl (same Ed25519 algorithm, compatible signatures).
+describe("Ed25519 signature verification", () => {
+  it("should verify a valid signature", () => {
+    const kp = generateEditKeyPair();
+    const sig = signContent("hello", kp.editKey);
+    expect(verifySignature("hello", sig, kp.publicKey)).toBe(true);
   });
 
-  it("should accept push with matching edit token", () => {
-    const result = validatePush("abc123", "abc123");
-    expect(result).toBe(true);
+  it("should reject a bad signature", () => {
+    const kp = generateEditKeyPair();
+    const sig = signContent("hello", kp.editKey);
+    expect(verifySignature("tampered", sig, kp.publicKey)).toBe(false);
   });
 
-  it("should reject push with wrong edit token", () => {
-    const result = validatePush("abc123", "wrong");
-    expect(result).toBe(false);
+  it("should reject a signature from a different key", () => {
+    const kp1 = generateEditKeyPair();
+    const kp2 = generateEditKeyPair();
+    const sig = signContent("hello", kp1.editKey);
+    expect(verifySignature("hello", sig, kp2.publicKey)).toBe(false);
   });
 
-  it("should reject push with missing edit token when one is set", () => {
-    const result = validatePush("abc123", undefined);
-    expect(result).toBe(false);
+  it("should reject malformed input", () => {
+    const kp = generateEditKeyPair();
+    expect(verifySignature("hello", "bad", kp.publicKey)).toBe(false);
   });
 });

--- a/src/party/livedown.ts
+++ b/src/party/livedown.ts
@@ -1,9 +1,18 @@
 import type * as Party from "partykit/server";
 
+export function validatePush(
+  roomToken: string | undefined,
+  msgToken: string | undefined
+): boolean {
+  if (!roomToken) return true;
+  return !!msgToken && roomToken === msgToken;
+}
+
 export default class LivedownRoom implements Party.Server {
   latestContent = "";
   latestMeta: Record<string, string> = {};
   guestCounter = 0;
+  editToken: string | undefined = undefined;
 
   constructor(readonly room: Party.Room) {}
 
@@ -18,6 +27,7 @@ export default class LivedownRoom implements Party.Server {
         content: this.latestContent,
         meta: this.latestMeta,
         guestId: this.guestCounter,
+        protected: !!this.editToken,
       })
     );
   }
@@ -25,7 +35,21 @@ export default class LivedownRoom implements Party.Server {
   onMessage(message: string, sender: Party.Connection) {
     try {
       const msg = JSON.parse(message);
+
+      if (msg.type === "set-token" && !this.editToken && msg.editToken) {
+        this.editToken = msg.editToken;
+        this.room.broadcast(
+          JSON.stringify({ type: "protected", protected: true })
+        );
+        return;
+      }
+
       if (msg.type !== "push") return;
+
+      if (!validatePush(this.editToken, msg.editToken)) {
+        sender.send(JSON.stringify({ type: "auth-error" }));
+        return;
+      }
 
       this.latestContent = msg.content;
       this.latestMeta = msg.meta || {};

--- a/src/party/livedown.ts
+++ b/src/party/livedown.ts
@@ -8,28 +8,17 @@ function fromHex(hex: string): Uint8Array {
   return bytes;
 }
 
-export async function verifySignature(
+async function verifySignature(
   content: string,
   signatureHex: string,
   publicKeyHex: string
 ): Promise<boolean> {
   try {
-    const msg = new Uint8Array(new TextEncoder().encode(content));
-    const sig = new Uint8Array(fromHex(signatureHex));
-    const pub = new Uint8Array(fromHex(publicKeyHex));
-    const key = await crypto.subtle.importKey(
-      "raw",
-      pub,
-      { name: "Ed25519" } as EcKeyImportParams,
-      false,
-      ["verify"]
-    );
-    return await crypto.subtle.verify(
-      { name: "Ed25519" } as EcdsaParams,
-      key,
-      sig,
-      msg
-    );
+    const { ed25519 } = await import("@noble/curves/ed25519.js");
+    const msg = new TextEncoder().encode(content);
+    const sig = fromHex(signatureHex);
+    const pub = fromHex(publicKeyHex);
+    return ed25519.verify(sig, msg, pub);
   } catch {
     return false;
   }

--- a/src/party/livedown.ts
+++ b/src/party/livedown.ts
@@ -1,18 +1,45 @@
 import type * as Party from "partykit/server";
 
-export function validatePush(
-  roomToken: string | undefined,
-  msgToken: string | undefined
-): boolean {
-  if (!roomToken) return true;
-  return !!msgToken && roomToken === msgToken;
+function fromHex(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+export async function verifySignature(
+  content: string,
+  signatureHex: string,
+  publicKeyHex: string
+): Promise<boolean> {
+  try {
+    const msg = new Uint8Array(new TextEncoder().encode(content));
+    const sig = new Uint8Array(fromHex(signatureHex));
+    const pub = new Uint8Array(fromHex(publicKeyHex));
+    const key = await crypto.subtle.importKey(
+      "raw",
+      pub,
+      { name: "Ed25519" } as EcKeyImportParams,
+      false,
+      ["verify"]
+    );
+    return await crypto.subtle.verify(
+      { name: "Ed25519" } as EcdsaParams,
+      key,
+      sig,
+      msg
+    );
+  } catch {
+    return false;
+  }
 }
 
 export default class LivedownRoom implements Party.Server {
   latestContent = "";
   latestMeta: Record<string, string> = {};
   guestCounter = 0;
-  editToken: string | undefined = undefined;
+  publicKey: string | undefined = undefined;
 
   constructor(readonly room: Party.Room) {}
 
@@ -27,32 +54,47 @@ export default class LivedownRoom implements Party.Server {
         content: this.latestContent,
         meta: this.latestMeta,
         guestId: this.guestCounter,
-        protected: !!this.editToken,
+        protected: !!this.publicKey,
+        publicKey: this.publicKey || null,
       })
     );
   }
 
-  onMessage(message: string, sender: Party.Connection) {
+  async onMessage(message: string, sender: Party.Connection) {
     try {
       const msg = JSON.parse(message);
 
-      if (msg.type === "set-token" && !this.editToken && msg.editToken) {
-        this.editToken = msg.editToken;
+      if (msg.type === "set-token" && !this.publicKey && msg.publicKey) {
+        this.publicKey = msg.publicKey;
         this.room.broadcast(
-          JSON.stringify({ type: "protected", protected: true })
+          JSON.stringify({
+            type: "protected",
+            protected: true,
+            publicKey: this.publicKey,
+          })
         );
         return;
       }
 
       if (msg.type !== "push") return;
 
-      if (!validatePush(this.editToken, msg.editToken)) {
-        sender.send(JSON.stringify({ type: "auth-error" }));
-        const editor = msg.meta?.editor || "unknown";
-        this.room.broadcast(JSON.stringify({ type: "auth-rejected", editor }), [
-          sender.id,
-        ]);
-        return;
+      if (this.publicKey) {
+        const valid =
+          msg.signature &&
+          (await verifySignature(
+            msg.content || "",
+            msg.signature,
+            this.publicKey
+          ));
+        if (!valid) {
+          sender.send(JSON.stringify({ type: "auth-error" }));
+          const editor = msg.meta?.editor || "unknown";
+          this.room.broadcast(
+            JSON.stringify({ type: "auth-rejected", editor }),
+            [sender.id]
+          );
+          return;
+        }
       }
 
       this.latestContent = msg.content;
@@ -63,6 +105,7 @@ export default class LivedownRoom implements Party.Server {
           type: "update",
           content: msg.content,
           meta: msg.meta || {},
+          signature: msg.signature || null,
         }),
         [sender.id]
       );

--- a/src/party/livedown.ts
+++ b/src/party/livedown.ts
@@ -48,6 +48,10 @@ export default class LivedownRoom implements Party.Server {
 
       if (!validatePush(this.editToken, msg.editToken)) {
         sender.send(JSON.stringify({ type: "auth-error" }));
+        const editor = msg.meta?.editor || "unknown";
+        this.room.broadcast(JSON.stringify({ type: "auth-rejected", editor }), [
+          sender.id,
+        ]);
         return;
       }
 

--- a/src/token.test.ts
+++ b/src/token.test.ts
@@ -1,14 +1,54 @@
-import { generateEditToken } from "./token";
+import {
+  generateEditKeyPair,
+  signContent,
+  verifySignature,
+  publicKeyFromEditKey,
+} from "./token";
 
-describe("generateEditToken", () => {
-  it("should return a 32-character hex string", () => {
-    const token = generateEditToken();
-    expect(token).toMatch(/^[0-9a-f]{32}$/);
+describe("generateEditKeyPair", () => {
+  it("should return 64-character hex strings for both keys", () => {
+    const kp = generateEditKeyPair();
+    expect(kp.editKey).toMatch(/^[0-9a-f]{64}$/);
+    expect(kp.publicKey).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it("should return unique values on each call", () => {
-    const a = generateEditToken();
-    const b = generateEditToken();
-    expect(a).not.toBe(b);
+  it("should return unique keypairs on each call", () => {
+    const a = generateEditKeyPair();
+    const b = generateEditKeyPair();
+    expect(a.editKey).not.toBe(b.editKey);
+    expect(a.publicKey).not.toBe(b.publicKey);
+  });
+});
+
+describe("signContent and verifySignature", () => {
+  it("should verify a valid signature", () => {
+    const kp = generateEditKeyPair();
+    const sig = signContent("hello world", kp.editKey);
+    expect(verifySignature("hello world", sig, kp.publicKey)).toBe(true);
+  });
+
+  it("should reject a signature for different content", () => {
+    const kp = generateEditKeyPair();
+    const sig = signContent("hello world", kp.editKey);
+    expect(verifySignature("tampered", sig, kp.publicKey)).toBe(false);
+  });
+
+  it("should reject a signature from a different key", () => {
+    const kp1 = generateEditKeyPair();
+    const kp2 = generateEditKeyPair();
+    const sig = signContent("hello", kp1.editKey);
+    expect(verifySignature("hello", sig, kp2.publicKey)).toBe(false);
+  });
+
+  it("should reject a malformed signature", () => {
+    const kp = generateEditKeyPair();
+    expect(verifySignature("hello", "badbeef", kp.publicKey)).toBe(false);
+  });
+});
+
+describe("publicKeyFromEditKey", () => {
+  it("should derive the same public key as generateEditKeyPair", () => {
+    const kp = generateEditKeyPair();
+    expect(publicKeyFromEditKey(kp.editKey)).toBe(kp.publicKey);
   });
 });

--- a/src/token.test.ts
+++ b/src/token.test.ts
@@ -1,0 +1,14 @@
+import { generateEditToken } from "./token";
+
+describe("generateEditToken", () => {
+  it("should return a 32-character hex string", () => {
+    const token = generateEditToken();
+    expect(token).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("should return unique values on each call", () => {
+    const a = generateEditToken();
+    const b = generateEditToken();
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,0 +1,5 @@
+import crypto from "crypto";
+
+export function generateEditToken(): string {
+  return crypto.randomBytes(16).toString("hex");
+}

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,5 +1,58 @@
-import crypto from "crypto";
+import nacl from "tweetnacl";
 
-export function generateEditToken(): string {
-  return crypto.randomBytes(16).toString("hex");
+export interface EditKeyPair {
+  editKey: string; // 64 hex chars — the secret shared with trusted editors
+  publicKey: string; // 64 hex chars — broadcast freely for verification
+}
+
+export function generateEditKeyPair(): EditKeyPair {
+  const seed = nacl.randomBytes(32);
+  const kp = nacl.sign.keyPair.fromSeed(seed);
+  return {
+    editKey: toHex(seed),
+    publicKey: toHex(kp.publicKey),
+  };
+}
+
+export function signContent(content: string, editKeyHex: string): string {
+  const seed = fromHex(editKeyHex);
+  const kp = nacl.sign.keyPair.fromSeed(seed);
+  const msg = new TextEncoder().encode(content);
+  const sig = nacl.sign.detached(msg, kp.secretKey);
+  return toHex(sig);
+}
+
+export function verifySignature(
+  content: string,
+  signatureHex: string,
+  publicKeyHex: string
+): boolean {
+  try {
+    const msg = new TextEncoder().encode(content);
+    const sig = fromHex(signatureHex);
+    const pub = fromHex(publicKeyHex);
+    return nacl.sign.detached.verify(msg, sig, pub);
+  } catch {
+    return false;
+  }
+}
+
+export function publicKeyFromEditKey(editKeyHex: string): string {
+  const seed = fromHex(editKeyHex);
+  const kp = nacl.sign.keyPair.fromSeed(seed);
+  return toHex(kp.publicKey);
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function fromHex(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
 }

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -34,7 +34,8 @@ export function startWatcher(
   filePath: string,
   doc: string,
   roomUrl: string,
-  editor: string
+  editor: string,
+  editToken: string
 ): void {
   let ws: WebSocket | null = null;
   let ignoreNextWrite = false;
@@ -46,6 +47,7 @@ export function startWatcher(
       JSON.stringify({
         type: "push",
         content,
+        editToken,
         meta: {
           ...meta,
           editor,
@@ -61,12 +63,17 @@ export function startWatcher(
 
     ws.on("open", () => {
       console.log("Connected to room");
+      ws!.send(JSON.stringify({ type: "set-token", editToken }));
       push(fs.readFileSync(filePath, "utf8"));
     });
 
     ws.on("message", (data: WebSocket.Data) => {
       try {
         const msg = JSON.parse(data.toString());
+        if (msg.type === "auth-error") {
+          console.error("Edit token rejected by relay — check your --edit-token value");
+          return;
+        }
         if (msg.type !== "update") return;
 
         const meta = msg.meta || {};

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -30,6 +30,20 @@ function parseMeta(
   };
 }
 
+const HINTS = "\x1b[2m  t copy edit key  q quit\x1b[0m";
+let showHints = false;
+
+function log(msg: string): void {
+  if (showHints && process.stdout.isTTY) {
+    // Clear current line (the hints), print message, reprint hints
+    process.stdout.write("\x1b[2K\r");
+    console.log(msg);
+    process.stdout.write(HINTS);
+  } else {
+    console.log(msg);
+  }
+}
+
 export function startWatcher(
   filePath: string,
   doc: string,
@@ -39,6 +53,7 @@ export function startWatcher(
 ): void {
   let ws: WebSocket | null = null;
   let ignoreNextWrite = false;
+  showHints = process.stdin.isTTY === true;
 
   function push(raw: string): void {
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
@@ -62,7 +77,10 @@ export function startWatcher(
     ws = new WebSocket(roomUrl);
 
     ws.on("open", () => {
-      console.log("Connected to room");
+      log("Connected to room");
+      if (showHints && process.stdout.isTTY) {
+        process.stdout.write(HINTS);
+      }
       ws!.send(JSON.stringify({ type: "set-token", editToken }));
       push(fs.readFileSync(filePath, "utf8"));
     });
@@ -71,14 +89,12 @@ export function startWatcher(
       try {
         const msg = JSON.parse(data.toString());
         if (msg.type === "auth-error") {
-          console.error(
-            "Edit token rejected by relay — check your --edit-token value"
-          );
+          log("Edit token rejected — check your --edit-token value");
           return;
         }
         if (msg.type === "auth-rejected") {
           const who = msg.editor || "unknown";
-          console.log(`  \x1b[31m✗ ${who} — edit rejected (bad token)\x1b[0m`);
+          log(`  \x1b[31m✗ ${who} — edit rejected (bad token)\x1b[0m`);
           return;
         }
         if (msg.type !== "update") return;
@@ -109,7 +125,7 @@ export function startWatcher(
             .slice(0, 60);
           const dim = "\x1b[2m";
           const reset = "\x1b[0m";
-          console.log(
+          log(
             `  ${dim}${who}${reset}  ${preview}${preview.length >= 60 ? "..." : ""}`
           );
         }
@@ -119,11 +135,11 @@ export function startWatcher(
     });
 
     ws.on("close", () => {
-      console.log("Disconnected — reconnecting in 2s...");
+      log("Disconnected — reconnecting in 2s...");
       setTimeout(connect, 2000);
     });
 
-    ws.on("error", (e: Error) => console.error("WS error:", e.message));
+    ws.on("error", (e: Error) => log(`WS error: ${e.message}`));
   }
 
   chokidar
@@ -136,7 +152,7 @@ export function startWatcher(
         return;
       }
       const raw = fs.readFileSync(filePath, "utf8");
-      console.log("Local change detected — pushing...");
+      log("Local change detected — pushing...");
       push(raw);
     });
 

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -71,7 +71,9 @@ export function startWatcher(
       try {
         const msg = JSON.parse(data.toString());
         if (msg.type === "auth-error") {
-          console.error("Edit token rejected by relay — check your --edit-token value");
+          console.error(
+            "Edit token rejected by relay — check your --edit-token value"
+          );
           return;
         }
         if (msg.type !== "update") return;

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -76,6 +76,11 @@ export function startWatcher(
           );
           return;
         }
+        if (msg.type === "auth-rejected") {
+          const who = msg.editor || "unknown";
+          console.log(`  \x1b[31m✗ ${who} — edit rejected (bad token)\x1b[0m`);
+          return;
+        }
         if (msg.type !== "update") return;
 
         const meta = msg.meta || {};

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -3,6 +3,7 @@ import path from "path";
 import chokidar from "chokidar";
 import matter from "gray-matter";
 import WebSocket from "ws";
+import { signContent, verifySignature } from "./token";
 
 interface Meta {
   owner: string | null;
@@ -35,7 +36,6 @@ let showHints = false;
 
 function log(msg: string): void {
   if (showHints && process.stdout.isTTY) {
-    // Clear current line (the hints), print message, reprint hints
     process.stdout.write("\x1b[2K\r");
     console.log(msg);
     process.stdout.write(HINTS);
@@ -49,7 +49,8 @@ export function startWatcher(
   doc: string,
   roomUrl: string,
   editor: string,
-  editToken: string
+  editKey: string,
+  publicKey: string
 ): void {
   let ws: WebSocket | null = null;
   let ignoreNextWrite = false;
@@ -58,11 +59,12 @@ export function startWatcher(
   function push(raw: string): void {
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
     const { content, meta } = parseMeta(raw, filePath);
+    const signature = signContent(content, editKey);
     ws.send(
       JSON.stringify({
         type: "push",
         content,
-        editToken,
+        signature,
         meta: {
           ...meta,
           editor,
@@ -81,7 +83,7 @@ export function startWatcher(
       if (showHints && process.stdout.isTTY) {
         process.stdout.write(HINTS);
       }
-      ws!.send(JSON.stringify({ type: "set-token", editToken }));
+      ws!.send(JSON.stringify({ type: "set-token", publicKey }));
       push(fs.readFileSync(filePath, "utf8"));
     });
 
@@ -89,15 +91,23 @@ export function startWatcher(
       try {
         const msg = JSON.parse(data.toString());
         if (msg.type === "auth-error") {
-          log("Edit token rejected — check your --edit-token value");
+          log("Edit key rejected — check your --edit-key value");
           return;
         }
         if (msg.type === "auth-rejected") {
           const who = msg.editor || "unknown";
-          log(`  \x1b[31m✗ ${who} — edit rejected (bad token)\x1b[0m`);
+          log(`  \x1b[31m✗ ${who} — edit rejected (bad signature)\x1b[0m`);
           return;
         }
         if (msg.type !== "update") return;
+
+        // Verify signature before writing to disk
+        if (msg.signature && publicKey) {
+          if (!verifySignature(msg.content || "", msg.signature, publicKey)) {
+            log("  \x1b[31m✗ Rejected update — invalid signature\x1b[0m");
+            return;
+          }
+        }
 
         const meta = msg.meta || {};
         let frontmatter = "";


### PR DESCRIPTION
## Summary
- Adds edit token system to protect local files from unauthorized remote edits
- CLI generates a random token on share, prints it, and offers to copy to clipboard
- PartyKit relay enforces the token — rejects unauthorized pushes with `auth-error`
- Browser viewer shows "(Read Only — Enter Edit Key)" with modal prompt for token entry
- Sharer's CLI shows rejected edit attempts in real-time
- TTY keyboard shortcuts: `t` to copy token, `q` to quit
- Adds `deploy.yaml` workflow for PartyKit deploys (auto on main + manual dispatch)
- Renames security agent and adds security principles (URLs are not credentials, defense in depth, no secrets in broadcasts)
- Updates project description across CLI, website, package.json, and README