### PR TITLE
fix: clean up CLI clipboard flow and add tab completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,47 @@ Livedown shares local markdown files live via WebSocket. Security is critical �
 
 ## Architecture
 
-See README.md "How It Works" for the architecture diagram, component descriptions, key libraries, and security model. **This documentation must be kept up to date** — any PR that changes the architecture, adds/removes dependencies, or modifies the security model must update the README accordingly.
+**Primary source of truth: [`docs/architecture.md`](docs/architecture.md).** It documents the component model, connection flow, browser state machine, and message types. **Keep it up to date** — any PR that changes the protocol, roles, state transitions, or message types must update it in the same PR.
 
-Specifically, keep current:
+README.md "How It Works" is the user-facing summary of the same information. Keep these in sync:
+
 - The architecture diagram and component descriptions
 - The "Key Libraries" table (add/remove entries when dependencies change)
 - The "Security" section (update when auth/signing logic changes)
 - The "PartyKit and Cloudflare Workers" section (update when relay infrastructure changes)
+
+## Testing
+
+### Unit tests
+```bash
+npm test       # jest
+npm run lint   # eslint
+npm run build  # tsc
+```
+
+### Browser end-to-end tests with Playwright
+
+Use the `playwright-webkit` MCP tools to test the browser viewer against a real running CLI. The standard test scenario:
+
+1. **Start the sharer** in one terminal:
+   ```bash
+   npm start -- share ./tests/documents/empty.md
+   ```
+   Note the Join URL and Edit key printed.
+
+2. **Test the viewer** with Playwright:
+   - **Join:** Navigate to the Join URL. Verify the main UI shows (no "not found" banner). The status bar should show "live".
+   - **Initial view:** Confirm the editor is visible and the document content (empty or otherwise) renders.
+   - **Edit without key:** Click the editor and try typing. The "Edit key required" modal should appear. The status bar should show "(Read Only — Enter Edit Key)".
+   - **Enter wrong key:** Paste an invalid key. The modal should show "Incorrect edit key" and stay open.
+   - **Enter correct key:** Paste the real edit key from the CLI. The modal should close, the editor should become writable, and the profile badge should switch to "(Editor)".
+   - **Edit:** Type in the editor. After the debounce (~400ms) the CLI should log the incoming edit.
+
+3. **Test sharer disconnect:** Press `q` in the CLI terminal to exit. The browser should transition to "sharer offline" state (status bar shows "sharer offline", content stays visible, editor becomes read-only). **It should NOT kick to the "not found" landing page.**
+
+4. **Test sharer reconnect:** Restart the CLI (same command, same edit key). The browser should transition back to "live" automatically.
+
+Always use `./tests/documents/empty.md` as the first test — it confirms empty documents work (they should, since content is not a presence signal).
 
 ## Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,18 @@ Livedown shares local markdown files live via WebSocket. Security is critical â€
 
 ## Architecture
 
-**Primary source of truth: [`docs/architecture.md`](docs/architecture.md).** It documents the component model, connection flow, browser state machine, and message types. **Keep it up to date** â€” any PR that changes the protocol, roles, state transitions, or message types must update it in the same PR.
+**Primary source of truth: [`docs/architecture.md`](docs/architecture.md).** It documents the overview diagram, journey flows, browser state machine, message types, and security model.
 
-README.md "How It Works" is the user-facing summary of the same information. Keep these in sync:
+**This documentation MUST be kept up to date.** Any PR that changes any of the following MUST update `docs/architecture.md` in the same PR:
+
+- Protocol or message types (new messages, changed fields)
+- Roles or connection lifecycle (how sharers/viewers register)
+- Browser state machine (new states, changed transitions)
+- Relay behavior (signature verification, broadcasting logic)
+- CLI output or startup sequence (handshake, keyboard shortcuts)
+- New journeys or major features
+
+README.md "How It Works" is the user-facing summary. Keep it in sync with the architecture doc:
 
 - The architecture diagram and component descriptions
 - The "Key Libraries" table (add/remove entries when dependencies change)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Livedown has three components:
 
 3. **Browser Viewer** (`public/index.html`) — renders the shared markdown with live preview and a CodeMirror editor. Viewers can read freely; editing requires the edit key.
 
+The CLI only prints the shareable URL **after** the relay acknowledges the sharer is registered. This means viewers can never arrive before the sharer is ready. The browser has an explicit state machine (`loading` / `live` / `offline` / `notfound`) driven entirely by relay messages — no timeouts, no guessing.
+
+For the complete protocol, state machine, and message types, see [`docs/architecture.md`](docs/architecture.md).
+
 ### Key Libraries
 
 | Library | Used In | Purpose |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,12 @@
 
 Livedown lets you share a local file and collaborate on it live - across browsers, terminals, IDEs, and machines. You edit locally, everyone else sees it instantly. Share a key and others can share and sync to their machines in real-time. Perfect for live collaboration on specs or designs, multi-person multi-agent live editing, connecting to GitHub to rapidly iterate on issue descriptions, pull requests and more.
 
+This page covers the essentials of how livedown works, and then some specific journeys:
+
+- [Sharing a local file to web](#journey-1-share-cli-to-web)
+- [Edit live, from local file to browser](#journey-2-edit-live-cli-to-web-edit-online)
+- [Sharing to a remote machine](#journey-3-share-to-remote-machine-future) - one file synchronised across machines with live collab
+
 ## Overview
 
 ```
@@ -11,23 +17,14 @@ Livedown lets you share a local file and collaborate on it live - across browser
                               └───────┬───────┘
                                       │ WebSocket
                                       │
-                            ┌─────────┴─────────┐
-                            │   Stateful Room   │
-   signed pushes            │   (Relay)         │            signed pushes
-  ┌────────────────────────▶│                   │◀────────────────────────┐
-  │            verified     │                   │     verified           │
-  │◀────────────────────────│                   │────────────────────────▶│
-  │                         └───────────────────┘                        │
-  │                              (PartyKit)                              │
-  │                                                                      │
-  ┌──────────────┐                                          ┌──────────────┐
-  │ CLI - Share  │                                          │ CLI - Join   │
-  │              │                                          │   (future)   │
-  │ (Local File) │                                          │ (Local File) │
-  └──────┬───────┘                                          └──────┬───────┘
-         │                                                         │
-  Editor (e.g. Vim)                                         Editor (e.g. Vim)
-  IDE (e.g. Cursor)                                         IDE (e.g. Cursor)
+  ┌──────────────┐          ┌─────────┴─────────┐          ┌──────────────┐
+  │  CLI - Share │  signed  │   Stateful Room   │  signed  │  CLI - Join  │
+  │              │──pushes─▶│                   │◀─pushes──│   (future)   │
+  │ (Local File) │◀verified─│       Relay       │─verified▶│ (Local File) │
+  └──────┬───────┘          └───────────────────┘          └──────┬───────┘
+         │                       (PartyKit)                       │
+         │                                                        │
+  Vim, Cursor, ...                                         Vim, Cursor, ...
 ```
 
 The relay is a stateful WebSocket room hosted on Cloudflare Workers via [PartyKit](https://partykit.io). It holds a single room per shared document, tracks which connections are sharers, verifies Ed25519 signatures on every push, and broadcasts verified updates to all connected clients. It also serves the browser viewer as a static HTML page.
@@ -39,6 +36,7 @@ The relay does not persist data. Rooms exist only while connections are active. 
 | **CLI + Watcher** | `src/cli.ts`, `src/watcher.ts` | Node.js | tweetnacl |
 | **Relay** | `src/party/livedown.ts` | Cloudflare Workers (PartyKit) | @noble/curves |
 | **Browser Viewer** | `public/index.html` | Browser | tweetnacl (CDN) |
+
 
 ## Journeys
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,19 +5,29 @@ Livedown lets you share a local file and collaborate on it live - across browser
 ## Overview
 
 ```
-                          ┌─────────────────────┐
-                          │   Browser Viewer    │
-                          │   (livedown.dev)    │
-                          └──────────┬──────────┘
-                                     │ WebSocket
-                                     │
-  ┌─────────────┐         ┌──────────┴──────────┐         ┌─────────────┐
-  │  Local File │  signed  │       Relay        │  signed  │  Local File │
-  │  (Machine A)│─pushes──▶│  (Cloudflare)      │◀─pushes──│  (Machine B)│
-  │             │◀verified─│                    │─verified─▶│             │
-  └─────────────┘          └─────────────────────┘          └─────────────┘
-    CLI watcher                 PartyKit                     CLI watcher
-                             (stateful room)                  (future)
+                              ┌───────────────┐
+                              │    Website    │
+                              │  (Viewer UI)  │
+                              └───────┬───────┘
+                                      │ WebSocket
+                                      │
+                            ┌─────────┴─────────┐
+                            │   Stateful Room   │
+   signed pushes            │   (Relay)         │            signed pushes
+  ┌────────────────────────▶│                   │◀────────────────────────┐
+  │            verified     │                   │     verified           │
+  │◀────────────────────────│                   │────────────────────────▶│
+  │                         └───────────────────┘                        │
+  │                              (PartyKit)                              │
+  │                                                                      │
+  ┌──────────────┐                                          ┌──────────────┐
+  │ CLI - Share  │                                          │ CLI - Join   │
+  │              │                                          │   (future)   │
+  │ (Local File) │                                          │ (Local File) │
+  └──────┬───────┘                                          └──────┬───────┘
+         │                                                         │
+  Editor (e.g. Vim)                                         Editor (e.g. Vim)
+  IDE (e.g. Cursor)                                         IDE (e.g. Cursor)
 ```
 
 The relay is a stateful WebSocket room hosted on Cloudflare Workers via [PartyKit](https://partykit.io). It holds a single room per shared document, tracks which connections are sharers, verifies Ed25519 signatures on every push, and broadcasts verified updates to all connected clients. It also serves the browser viewer as a static HTML page.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,211 @@
+# Livedown Architecture
+
+This document describes the components, connection flow, and state machines that govern how livedown shares a local file with remote viewers. It is the source of truth for the "how it works" story and must be kept up to date when the protocol, roles, or state transitions change.
+
+## Components
+
+```
+   ┌───────────────────┐        ┌───────────────────┐        ┌─────────────────┐
+   │                   │        │                   │        │                 │
+   │  CLI + Watcher    │        │   Relay (Party)   │        │  Browser Viewer │
+   │                   │        │                   │        │                 │
+   │  - Node.js        │        │  - Cloudflare     │        │  - Static HTML  │
+   │  - File I/O       │───────▶│    Worker         │◀───────│  - CodeMirror   │
+   │  - Signs pushes   │   WS   │  - Stateful room  │   WS   │  - tweetnacl    │
+   │  - Verifies       │        │  - Verifies sigs  │        │    (CDN)        │
+   │    incoming       │        │  - Tracks sharers │        │  - Verifies     │
+   │  - tweetnacl      │        │  - @noble/curves  │        │    public key   │
+   │                   │        │                   │        │    on unlock    │
+   └───────────────────┘        └───────────────────┘        └─────────────────┘
+```
+
+Three components, all talking WebSocket. The relay is stateful per room; everything else is stateless.
+
+## Roles
+
+A connection to the relay has one of two roles:
+
+| Role        | Becomes by...                              | Can push? |
+|-------------|--------------------------------------------|-----------|
+| **Sharer**  | Sending `set-token` with matching pubkey   | Yes       |
+| **Viewer**  | Just connecting                            | Only with edit key |
+
+The relay distinguishes roles via a `sharers: Set<string>` of connection IDs. When the last sharer disconnects, the relay broadcasts `sharer-gone` and the room becomes effectively empty (viewers can still view the last content, but no more pushes are possible until a new sharer arrives).
+
+## Connection flow (happy path)
+
+```
+  CLI              Watcher            Relay                       Browser
+   │                 │                  │                            │
+   │ livedown share  │                  │                            │
+   │────────────────▶│                  │                            │
+   │ print "Watching ./file.md"         │                            │
+   │ print "Connecting..."              │                            │
+   │                 │                  │                            │
+   │                 │── WebSocket ────▶│                            │
+   │                 │                  │ onConnect                  │
+   │                 │                  │   guestId++                │
+   │                 │◀── init ─────────│                            │
+   │                 │                  │                            │
+   │                 │── set-token ────▶│                            │
+   │                 │   { publicKey }  │ sharers.add(conn.id)       │
+   │                 │                  │ publicKey = X              │
+   │                 │◀── sharer-ack ───│                            │
+   │                 │                  │                            │
+   │                 │── push ─────────▶│                            │
+   │                 │   { content,     │ verify signature OK        │
+   │                 │     signature }  │ latestContent = content    │
+   │                 │                  │                            │
+   │◀─── ready ──────│                  │                            │
+   │                 │                  │                            │
+   │ print "Join     https://.../#abc"  │                            │
+   │ print "Edit key ...(press c)..."   │                            │
+   │ print hint line                    │                            │
+   │                 │                  │                            │
+   │                                    │                            │
+   │                                    │◀── WebSocket ──────────────│
+   │                                    │ onConnect                  │
+   │                                    │   guestId++                │
+   │                                    │── init ───────────────────▶│
+   │                                    │   hasSharer: true          │
+   │                                    │   content: "..."           │
+   │                                    │   publicKey: X             │
+   │                                    │                          ✓ Live
+```
+
+**Key property: the Join URL is never printed before the relay has acknowledged the sharer.** The user cannot see or share the URL until the room is fully established. This eliminates the race where a viewer arrives before the sharer.
+
+## Browser state machine
+
+```
+               ┌────────────┐
+               │  Loading   │   initial state, websocket opening
+               └─────┬──────┘
+                     │ init arrives
+                     │
+              ┌──────┴──────┐
+              │             │
+          hasSharer?    hasSharer?
+             true          false
+              │             │
+              ▼             ▼
+       ┌──────────┐   ┌───────────┐
+       │   Live   │   │ NotFound  │
+       └────┬─────┘   └─────┬─────┘
+            │               │
+            │sharer-gone    │sharer-here
+            │               │
+            ▼               ▼
+       ┌──────────┐   ┌──────────┐
+       │ Offline  │──▶│   Live   │
+       └──────────┘   └──────────┘
+            ▲              │
+            │sharer-here   │sharer-gone
+            └──────────────┘
+```
+
+### State descriptions
+
+| State     | What the user sees                                                    | Edits allowed? |
+|-----------|-----------------------------------------------------------------------|----------------|
+| Loading   | Spinner, "Connecting..."                                              | No             |
+| Live      | Status bar, editor, preview, last known content                       | If unlocked    |
+| Offline   | Status bar with "sharer offline" indicator, editor in read-only mode, last known content still visible | No             |
+| NotFound  | Landing page with "not found — no one is sharing this document"       | No             |
+
+### Transitions
+
+| From      | Event           | To        | Why |
+|-----------|-----------------|-----------|-----|
+| Loading   | `init hasSharer:true` | Live      | Sharer was already registered |
+| Loading   | `init hasSharer:false`| NotFound  | No sharer; ghost room |
+| NotFound  | `sharer-here`   | Live      | User started CLI after opening browser |
+| Live      | `sharer-gone`   | Offline   | Sharer disconnected (maybe temporarily) |
+| Offline   | `sharer-here`   | Live      | Sharer reconnected (CLI restart, network blip) |
+
+**No timeouts anywhere.** Every transition is triggered by an explicit relay message. The browser never guesses.
+
+## Why the old approach was broken
+
+The old code tried to infer presence from **content**:
+
+```js
+if (msg.content) gotContent = true;
+// ... 8 seconds later ...
+if (!gotContent) showNotFound();
+```
+
+This broke because:
+1. **Empty documents look identical to no-sharer rooms.** A new blank file is a perfectly valid thing to share.
+2. **Content is not a presence signal.** The relay can have a sharer without any content yet (initial push hasn't arrived).
+3. **Timeouts guess.** An 8-second wait is both too long (bad UX for genuine not-found) and too short (bad UX for slow networks).
+
+The structural fix replaces content inference with explicit relay state:
+- Relay tracks sharers as a `Set<string>` of connection IDs
+- `init` message carries an authoritative `hasSharer: boolean` flag
+- `sharer-here` / `sharer-gone` broadcasts handle live transitions
+
+## Message types
+
+### Sharer → Relay
+
+| Type | Fields | Purpose |
+|------|--------|---------|
+| `set-token` | `publicKey` | Register as a sharer. Relay adds connection to `sharers` and stores the public key (first one wins; subsequent messages must match). |
+| `push` | `content`, `signature`, `meta` | Push new content. Signature must be valid against the stored public key. |
+
+### Relay → Sharer only
+
+| Type | Fields | Purpose |
+|------|--------|---------|
+| `sharer-ack` | — | Confirms the `set-token` was accepted. CLI waits for this before printing the Join URL. |
+| `auth-error` | — | Your push was rejected (bad signature). |
+
+### Relay → Viewer broadcasts
+
+| Type | Fields | Purpose |
+|------|--------|---------|
+| `init` | `content`, `meta`, `guestId`, `hasSharer`, `protected`, `publicKey` | Sent once per connection, immediately on connect. |
+| `update` | `content`, `meta`, `signature` | Broadcast after a valid push. |
+| `sharer-here` | `protected`, `publicKey` | Broadcast when a sharer joins an empty room. Viewers in `NotFound` or `Offline` transition to `Live`. |
+| `sharer-gone` | — | Broadcast when the last sharer disconnects. Viewers in `Live` transition to `Offline`. |
+| `auth-rejected` | `editor` | Information for the sharer: someone else tried to push with a bad key. |
+
+## Security model
+
+See also [Security](../README.md#security) in the README.
+
+- **Ed25519 keypairs**: the CLI generates a 32-byte seed (the "edit key"). The public key is sent to the relay via `set-token`. The private key stays with the sharer and any authorized editors.
+- **Defense in depth**: the relay verifies signatures before broadcasting; the watcher verifies signatures before writing to disk. A compromised relay cannot forge updates.
+- **URLs are locators, not credentials**: the viewer URL is safe to share publicly. Editing requires the edit key, which is entered out-of-band (pasted into the browser modal or shared through a trusted channel).
+- **Never implement cryptographic code**: `tweetnacl` in Node and browser, `@noble/curves` in the relay (PartyKit bundler can't handle tweetnacl's optional `require('crypto')`). Both implement RFC 8032 Ed25519 and produce interchangeable signatures.
+
+## Edge cases
+
+### Viewer arrives before sharer
+Impossible in the happy path — the CLI doesn't print the URL until `sharer-ack` arrives. If the user saves the URL from a previous session and visits it, they land in `NotFound`. If they then start the CLI, they get `sharer-here` and transition to `Live`.
+
+### Sharer disconnects mid-session
+Relay calls `onClose`, removes from `sharers`, broadcasts `sharer-gone`. Viewers enter `Offline`. The editor becomes read-only but the last known content stays visible. When the CLI reconnects (manual restart or automatic reconnect loop), the new `set-token` triggers `sharer-here` and viewers return to `Live`.
+
+### CLI network blip (Wi-Fi dropped briefly)
+Watcher's WebSocket closes, reconnects after 2s. Relay sees disconnect → `sharer-gone`. Reconnect → new `set-token` → `sharer-here`. Viewers briefly see `Offline` then return to `Live`. Content is not lost; any edits made during the blip are pushed as soon as the connection is re-established.
+
+### Multiple sharers (future)
+Already supported by the `sharers: Set<string>`. Two CLIs can run against the same room (same public key) and both are counted as sharers. `hasSharer` stays true as long as at least one is connected.
+
+### Empty document
+`latestContent === ""` is valid. `hasSharer` is independent of content. The viewer enters `Live` with an empty editor.
+
+### Ghost rooms (old URL, no sharer)
+`init.hasSharer: false` immediately. Viewer goes straight to `NotFound`. No timeout involved.
+
+## What must be kept in sync with this document
+
+- `src/party/livedown.ts` — roles, message types, state transitions
+- `src/watcher.ts` — sharer connection lifecycle, `sharer-ack` handling
+- `src/cli.ts` — when the URL is printed (must be after ready)
+- `public/index.html` — browser state machine, message handling
+- `README.md` "How It Works" section — user-facing summary
+
+If you change any of these, update this document in the same PR.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,21 +1,28 @@
 # Livedown Architecture
 
-Livedown lets you share a local file and collaborate on it live — across browsers, terminals, and machines. You edit locally, everyone else sees it instantly.
+Livedown lets you share a local file and collaborate on it live - across browsers, terminals, IDEs, and machines. You edit locally, everyone else sees it instantly. Share a key and others can share and sync to their machines in real-time. Perfect for live collaboration on specs or designs, multi-person multi-agent live editing, connecting to GitHub to rapidly iterate on issue descriptions, pull requests and more.
 
 ## Overview
 
 ```
-  ┌─────────┐              ┌─────────┐              ┌─────────┐
-  │  Local   │    signed    │  Relay  │   updates    │ Remote  │
-  │  File    │────pushes───▶│ (Cloud) │─────────────▶│ Viewers │
-  │          │◀──verified───│         │◀──signed─────│         │
-  └─────────┘   WebSocket   └─────────┘  WebSocket   └─────────┘
-     CLI                    PartyKit /                Browser or
-     watcher               Cloudflare                  another
-                             Workers                     CLI
+                          ┌─────────────────────┐
+                          │   Browser Viewer    │
+                          │   (livedown.dev)    │
+                          └──────────┬──────────┘
+                                     │ WebSocket
+                                     │
+  ┌─────────────┐         ┌──────────┴──────────┐         ┌─────────────┐
+  │  Local File │  signed  │       Relay        │  signed  │  Local File │
+  │  (Machine A)│─pushes──▶│  (Cloudflare)      │◀─pushes──│  (Machine B)│
+  │             │◀verified─│                    │─verified─▶│             │
+  └─────────────┘          └─────────────────────┘          └─────────────┘
+    CLI watcher                 PartyKit                     CLI watcher
+                             (stateful room)                  (future)
 ```
 
-Three components. All communication is via WebSocket. The relay is stateful per room (tracks who's sharing, verifies signatures, broadcasts updates). Everything else is stateless.
+The relay is a stateful WebSocket room hosted on Cloudflare Workers via [PartyKit](https://partykit.io). It holds a single room per shared document, tracks which connections are sharers, verifies Ed25519 signatures on every push, and broadcasts verified updates to all connected clients. It also serves the browser viewer as a static HTML page.
+
+The relay does not persist data. Rooms exist only while connections are active. When the last client disconnects, the room state is lost.
 
 | Component | Code | Runtime | Crypto |
 |-----------|------|---------|--------|
@@ -25,128 +32,123 @@ Three components. All communication is via WebSocket. The relay is stateful per 
 
 ## Journeys
 
-### Journey 1: Share (CLI → Web)
+### Journey 1: Share (CLI to Web)
 
 The sharer runs `livedown share ./file.md`. A viewer opens the URL in a browser.
 
 ```
-  Terminal                           Cloud                         Browser
+  Terminal                           Relay                         Browser
   ────────                           ─────                         ───────
 
   $ livedown share ./file.md
   │
-  │ generate Ed25519 keypair
-  │ print "Watching ./file.md"
-  │ print "Connecting..."
+  1. Generate Ed25519 keypair
   │
-  │ startWatcher()
-  │         │
-  │         │──── WebSocket ────────▶ Relay
-  │         │                         │ onConnect
-  │         │◀──── init ──────────────│
-  │         │                         │
-  │         │──── set-token ─────────▶│
-  │         │     { publicKey }       │ sharers.add(conn)
-  │         │◀──── sharer-ack ───────│
-  │         │                         │
-  │         │──── push ──────────────▶│
-  │         │     { content,          │ verify sig ✓
-  │         │       signature }       │ store content
-  │         │                         │
-  │◀── ready                          │
-  │                                   │
-  │ print "Join  https://.../#abc"    │
-  │ print "Edit key  f7a2c9e1..."     │
-  │ print "o open  c copy  q quit"    │
-  │                                   │
-  │                                   │         User opens URL
-  │                                   │◀──────── WebSocket ────────── │
-  │                                   │ onConnect                     │
-  │                                   │──────── init ────────────────▶│
-  │                                   │  hasSharer: true              │
-  │                                   │  content: "..."               │
-  │                                   │  publicKey: X                 │
-  │                                   │                            ✓ Live
-  │                                   │                            Content
-  │                                   │                            renders
+  2. Connect to relay
+  │         │──── WebSocket ────────▶│
+  │         │◀──── init ─────────────│
+  │         │                        │
+  3. Register as sharer
+  │         │──── set-token ────────▶│
+  │         │     { publicKey }      │ sharers.add(conn)
+  │         │◀──── sharer-ack ──────│
+  │         │                        │
+  4. Push initial content
+  │         │──── push ─────────────▶│
+  │         │     { content, sig }   │ verify sig, store content
+  │         │                        │
+  5. Show join info
+  │                                  │
+  │  Watching  ./file.md             │
+  │  Join      https://.../#abc      │
+  │  Edit key  f7a2c9e1...           │
+  │  o open  c copy key  q quit     │
+  │                                  │
+  │                                  │         6. Viewer opens URL
+  │                                  │◀──────── WebSocket ──────────│
+  │                                  │──────── init ───────────────▶│
+  │                                  │  hasSharer: true             │
+  │                                  │  content: "..."              │
+  │                                  │  publicKey: X                │
+  │                                  │                           7. Live
+  │                                  │                           Content renders
+  │                                  │                           Editor is read-only
 ```
 
-**Key property:** the Join URL is never printed before the relay confirms the sharer is registered (`sharer-ack`). The viewer can never arrive at an empty room via a freshly printed URL.
+1. **Generate keypair** - the CLI creates an Ed25519 keypair. The private key seed (64 hex chars) is the "edit key" shared with trusted editors. The public key goes to the relay.
+2. **Connect** - the watcher opens a WebSocket to the relay. The relay assigns a guest ID and sends an `init` message.
+3. **Register** - the watcher sends `set-token` with the public key. The relay adds the connection to its `sharers` set and replies with `sharer-ack`.
+4. **Push** - the watcher reads the local file, signs the content, and pushes it. The relay verifies the signature and stores the content.
+5. **Show join info** - the CLI only prints the join URL and edit key *after* receiving `sharer-ack`. The URL is never visible before the room is established.
+6. **Viewer connects** - the browser opens a WebSocket. The relay sends `init` with `hasSharer: true` and the current content.
+7. **Live** - the browser renders the content. The editor is read-only until the viewer enters an edit key.
 
-### Journey 2: Edit Live (CLI → Web ← Edit Online)
+### Journey 2: Edit live (CLI to Web, edit online)
 
-A viewer with the edit key makes changes in the browser. The sharer's local file is updated.
+A viewer with the edit key makes changes in the browser. The sharer's local file updates.
 
 ```
-  Terminal               Cloud                    Browser
+  Terminal               Relay                    Browser
   ────────               ─────                    ───────
 
   (watching ./file.md)    (room live)              (viewing, read-only)
   │                       │                        │
-  │                       │                        │ User clicks
-  │                       │                        │ "Enter Edit Key"
+  │                       │                        1. Enter edit key
+  │                       │                        │  (64 hex chars)
   │                       │                        │
-  │                       │                        │ Pastes edit key
-  │                       │                        │ (64 hex chars)
+  │                       │                        2. Browser derives keypair,
+  │                       │                        │  verifies public key
+  │                       │                        │  matches room
   │                       │                        │
-  │                       │                        │ Browser derives
-  │                       │                        │ keypair from seed,
-  │                       │                        │ verifies public key
-  │                       │                        │ matches room's
+  │                       │                        │  Editor unlocked
   │                       │                        │
-  │                       │                        │ ✓ Editor unlocked
-  │                       │                        │
-  │                       │                        │ User types in
-  │                       │                        │ CodeMirror editor
-  │                       │                        │ (400ms debounce)
+  │                       │                        3. User types in editor
+  │                       │                        │  (400ms debounce)
   │                       │                        │
   │                       │◀──── push ─────────────│
-  │                       │  { content: "new text", │
-  │                       │    signature: "abc..." } │
+  │                       │  { content, signature } │
   │                       │                        │
-  │                       │ verify sig ✓           │
-  │                       │ store content          │
+  │                       4. Relay verifies sig
   │                       │                        │
-  │                       │──── update ───────────▶│ (other viewers)
-  │◀──── update ──────────│  { content, sig }      │
-  │  { content,           │                        │
-  │    signature }        │                        │
+  │◀──── update ──────────│──── update ───────────▶│ (other viewers)
+  │  { content, sig }     │                        │
   │                       │                        │
-  │ verify sig ✓          │                        │
-  │ write to ./file.md    │                        │
+  5. Watcher verifies sig │                        │
+  │  write to ./file.md   │                        │
   │                       │                        │
   │  dave  new text...    │                        │
   │                       │                        │
 
   Wrong key? ──────────────────────────────────────│
   │                       │◀──── push (bad sig) ───│
-  │                       │ verify sig ✗           │
+  │                       │ verify sig fails       │
   │                       │──── auth-error ───────▶│ Modal shows error
-  │  ✗ Guest 3 — rejected │──── auth-rejected ────▶│ (other viewers)
+  │  x Guest 3 - rejected │──── auth-rejected ────▶│ (other viewers)
 ```
 
-**Three verification points:** the relay verifies before broadcasting, the watcher verifies before writing to disk, and the browser verifies the public key on entry. Even a compromised relay cannot forge updates that the watcher accepts.
+1. **Enter edit key** - the viewer clicks "Enter Edit Key" in the status bar and pastes the 64-character hex key.
+2. **Verify locally** - the browser derives the Ed25519 keypair from the seed and checks that the derived public key matches the room's public key. Wrong keys are rejected immediately without hitting the relay.
+3. **Type** - the viewer types in the CodeMirror editor. After a 400ms debounce, the browser signs the content and sends a `push` message.
+4. **Relay verifies** - the relay checks the signature against the stored public key. Valid pushes are broadcast as `update` messages. Invalid pushes get `auth-error` back to the sender and `auth-rejected` broadcast to other connections (so the sharer's CLI can log them).
+5. **Watcher verifies** - the watcher independently verifies the signature before writing to disk. Even a compromised relay cannot forge updates that pass this check.
 
-### Journey 3: Share to Remote Machine (Future — In Progress)
+### Journey 3: Share to remote machine (future)
 
 Two people share a file across machines. One is the leader, the other joins and gets a local copy.
 
 ```
-  Machine A                Cloud                    Machine B
+  Machine A                Relay                    Machine B
   ─────────                ─────                    ─────────
 
   $ livedown share ./notes.md
   │                         │
-  │ (same as Journey 1)     │
-  │ ...                     │
-  │ print Join URL          │
-  │ print Edit key          │
+  1-5. (same as Journey 1)  │
   │                         │
-  │ Share URL + edit key    │                        │
-  │ with Machine B          │                        │
-  │ (via Slack, email...)   │                        │
-  │                         │                        │
-  │                         │            $ livedown join <url>
+  │  Join URL + edit key    │
+  │  shared out-of-band    │
+  │  (Slack, email, etc.)   │
+  │                         │
+  │                         │         6. $ livedown join <url>
   │                         │                --edit-key <key>
   │                         │                        │
   │                         │◀─── WebSocket ─────────│
@@ -157,39 +159,37 @@ Two people share a file across machines. One is the leader, the other joins and 
   │                         │  sharers.add(B)        │
   │                         │──── sharer-ack ───────▶│
   │                         │                        │
-  │                         │                        │ write content to
-  │                         │                        │ ./local-notes.md
+  │                         │                     7. Write content to
+  │                         │                        ./local-notes.md
+  │                         │                        Watch local file
   │                         │                        │
-  │                         │                        │ watch local file
-  │                         │                        │
-  │ User A edits            │                        │
-  │ ./notes.md              │                        │
-  │                         │                        │
+  8. User A edits locally   │                        │
   │──── push ──────────────▶│                        │
-  │                         │ verify ✓               │
+  │                         │ verify, broadcast      │
   │                         │──── update ───────────▶│
-  │                         │                        │ verify ✓
-  │                         │                        │ write to local file
+  │                         │                        │ verify, write
   │                         │                        │
-  │                         │               User B edits
-  │                         │               ./local-notes.md
+  │                         │               9. User B edits locally
   │                         │                        │
   │                         │◀──── push ─────────────│
-  │                         │ verify ✓               │
-  │◀──── update ────────────│                        │
-  │ verify ✓                │                        │
-  │ write to ./notes.md     │                        │
+  │◀──── update ────────────│ verify, broadcast      │
+  │ verify, write           │                        │
   │                         │                        │
-  │ Both machines in sync   │    Both machines in sync
+  │  Both machines in sync  │     Both machines in sync
 ```
 
-**Status:** not yet implemented. Requires a `livedown join` command that downloads content, creates a local file, and starts a watcher in the reverse direction. The `sharers: Set` in the relay already supports multiple sharers — no relay changes needed.
+6. **Join** - Machine B runs `livedown join` with the URL and edit key. It connects to the relay, receives the current content, and registers as a second sharer.
+7. **Create local copy** - the joiner writes the received content to a local file and starts watching it for changes.
+8. **Edits flow A to B** - when User A edits their local file, the watcher pushes signed content. The relay verifies and broadcasts. Machine B's watcher verifies and writes to its local file.
+9. **Edits flow B to A** - the reverse. Both machines stay in sync via the relay.
 
-## Browser State Machine
+**Status:** not yet implemented. Requires a `livedown join` command. The relay already supports multiple sharers via its `sharers: Set` - no relay changes needed.
+
+## Browser state machine
 
 ```
             ┌────────────┐
-            │  Loading   │   spinner visible, ws connecting
+            │  Loading   │   spinner, ws connecting
             └─────┬──────┘
                   │ init arrives
                   │
@@ -198,67 +198,67 @@ Two people share a file across machines. One is the leader, the other joins and 
        hasSharer      hasSharer
          true           false
            │             │
-           ▼             ▼
+           v             v
     ┌──────────┐   ┌───────────┐
     │   Live   │   │ NotFound  │
     └────┬─────┘   └─────┬─────┘
          │               │
          │sharer-gone    │sharer-here
          │               │
-         ▼               ▼
+         v               v
     ┌──────────┐   ┌──────────┐
-    │ Offline  │──▶│   Live   │
+    │ Offline  │-->│   Live   │
     └──────────┘   └──────────┘
-         ▲              │
+         ^              │
          │sharer-here   │sharer-gone
          └──────────────┘
 ```
 
-| State     | UI | Edits? |
-|-----------|----|--------|
-| Loading   | Spinner, "Connecting..." | No |
-| Live      | Editor + preview, status bar shows "live" | If edit key entered |
-| Offline   | Same UI, status bar shows "sharer offline", editor read-only | No |
-| NotFound  | Landing page, "no one is sharing this document" | No |
+| State | UI | Edits? |
+|-------|-----|--------|
+| Loading | Spinner, "Connecting..." | No |
+| Live | Editor + preview, status bar shows "live" | If edit key entered |
+| Offline | Same UI, status bar shows "sharer offline", editor read-only | No |
+| NotFound | Landing page, "no one is sharing this document" | No |
 
 **Rule:** NotFound is only reachable from Loading. Once Live, the viewer can only go to Offline (recoverable), never back to the landing page.
 
-## Message Types
+## Message types
 
-### Client → Relay
+### Client to Relay
 
 | Type | Fields | Sent by |
 |------|--------|---------|
 | `set-token` | `publicKey` | Sharer (on connect) |
 | `push` | `content`, `signature`, `meta` | Sharer or unlocked viewer |
 
-### Relay → Sender only
+### Relay to sender only
 
 | Type | Purpose |
 |------|---------|
-| `sharer-ack` | set-token accepted; CLI prints URL |
+| `sharer-ack` | set-token accepted; CLI shows join URL |
 | `auth-error` | push rejected (bad signature) |
 
-### Relay → All (broadcast)
+### Relay to all (broadcast)
 
 | Type | Fields | Purpose |
 |------|--------|---------|
 | `init` | `content`, `meta`, `guestId`, `hasSharer`, `protected`, `publicKey` | Sent to each connection on connect |
 | `update` | `content`, `meta`, `signature` | After a valid push |
 | `sharer-here` | `protected`, `publicKey` | Sharer joined an empty room |
-| `sharer-gone` | — | Last sharer disconnected |
+| `sharer-gone` | - | Last sharer disconnected |
 | `auth-rejected` | `editor` | Someone's push was rejected (info for sharer) |
 
 ## Security
 
 See [Security Principles](../.claude/agents/security.md) for the full set of rules.
 
-- **Ed25519 signing** — pushes are signed with the edit key (private), verified with the public key
-- **Defense in depth** — relay verifies before broadcasting; watcher verifies before writing to disk
-- **URLs are locators, not credentials** — the viewer URL is safe to share publicly
-- **No custom crypto** — tweetnacl (Node/browser) and @noble/curves (relay) only
+- **Ed25519 signing** - pushes are signed with the edit key (private), verified with the public key
+- **Defense in depth** - relay verifies before broadcasting; watcher verifies before writing to disk
+- **URLs are locators, not credentials** - the viewer URL is safe to share publicly
+- **No custom crypto** - tweetnacl (Node/browser) and @noble/curves (relay) only
 
-## What Must Stay in Sync
+## What must stay in sync
 
 Any PR that changes the protocol, message types, or state transitions must update:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,13 +115,18 @@ The relay distinguishes roles via a `sharers: Set<string>` of connection IDs. Wh
 
 ### Transitions
 
-| From      | Event           | To        | Why |
-|-----------|-----------------|-----------|-----|
-| Loading   | `init hasSharer:true` | Live      | Sharer was already registered |
-| Loading   | `init hasSharer:false`| NotFound  | No sharer; ghost room |
-| NotFound  | `sharer-here`   | Live      | User started CLI after opening browser |
-| Live      | `sharer-gone`   | Offline   | Sharer disconnected (maybe temporarily) |
-| Offline   | `sharer-here`   | Live      | Sharer reconnected (CLI restart, network blip) |
+| From      | Event                  | To        | Why |
+|-----------|------------------------|-----------|-----|
+| Loading   | `init hasSharer:true`  | Live      | Sharer was already registered |
+| Loading   | `init hasSharer:false` | NotFound  | First init, no sharer; ghost room |
+| NotFound  | `sharer-here`          | Live      | User started CLI after opening browser |
+| Live      | `sharer-gone`          | Offline   | Sharer disconnected (maybe temporarily) |
+| Live      | `init hasSharer:false` | Offline   | Viewer's own ws reconnected and sharer isn't there right now — *not* NotFound, because we've seen a sharer before |
+| Live      | `init hasSharer:true`  | Live      | Viewer's own ws reconnected, sharer still there |
+| Offline   | `sharer-here`          | Live      | Sharer reconnected (CLI restart, network blip) |
+| Offline   | `init hasSharer:true`  | Live      | Viewer's ws reconnected and sharer is already back |
+
+**Rule: NotFound is only reachable from Loading.** Once a viewer has been Live, they can never return to NotFound — only to Offline. Transitioning back to the landing page after the user has been editing would discard their session and be a bad UX. The Offline state keeps content visible, disables editing, and recovers automatically when the sharer returns.
 
 **No timeouts anywhere.** Every transition is triggered by an explicit relay message. The browser never guesses.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,216 +1,267 @@
 # Livedown Architecture
 
-This document describes the components, connection flow, and state machines that govern how livedown shares a local file with remote viewers. It is the source of truth for the "how it works" story and must be kept up to date when the protocol, roles, or state transitions change.
+Livedown lets you share a local file and collaborate on it live — across browsers, terminals, and machines. You edit locally, everyone else sees it instantly.
 
-## Components
-
-```
-   ┌───────────────────┐        ┌───────────────────┐        ┌─────────────────┐
-   │                   │        │                   │        │                 │
-   │  CLI + Watcher    │        │   Relay (Party)   │        │  Browser Viewer │
-   │                   │        │                   │        │                 │
-   │  - Node.js        │        │  - Cloudflare     │        │  - Static HTML  │
-   │  - File I/O       │───────▶│    Worker         │◀───────│  - CodeMirror   │
-   │  - Signs pushes   │   WS   │  - Stateful room  │   WS   │  - tweetnacl    │
-   │  - Verifies       │        │  - Verifies sigs  │        │    (CDN)        │
-   │    incoming       │        │  - Tracks sharers │        │  - Verifies     │
-   │  - tweetnacl      │        │  - @noble/curves  │        │    public key   │
-   │                   │        │                   │        │    on unlock    │
-   └───────────────────┘        └───────────────────┘        └─────────────────┘
-```
-
-Three components, all talking WebSocket. The relay is stateful per room; everything else is stateless.
-
-## Roles
-
-A connection to the relay has one of two roles:
-
-| Role        | Becomes by...                              | Can push? |
-|-------------|--------------------------------------------|-----------|
-| **Sharer**  | Sending `set-token` with matching pubkey   | Yes       |
-| **Viewer**  | Just connecting                            | Only with edit key |
-
-The relay distinguishes roles via a `sharers: Set<string>` of connection IDs. When the last sharer disconnects, the relay broadcasts `sharer-gone` and the room becomes effectively empty (viewers can still view the last content, but no more pushes are possible until a new sharer arrives).
-
-## Connection flow (happy path)
+## Overview
 
 ```
-  CLI              Watcher            Relay                       Browser
-   │                 │                  │                            │
-   │ livedown share  │                  │                            │
-   │────────────────▶│                  │                            │
-   │ print "Watching ./file.md"         │                            │
-   │ print "Connecting..."              │                            │
-   │                 │                  │                            │
-   │                 │── WebSocket ────▶│                            │
-   │                 │                  │ onConnect                  │
-   │                 │                  │   guestId++                │
-   │                 │◀── init ─────────│                            │
-   │                 │                  │                            │
-   │                 │── set-token ────▶│                            │
-   │                 │   { publicKey }  │ sharers.add(conn.id)       │
-   │                 │                  │ publicKey = X              │
-   │                 │◀── sharer-ack ───│                            │
-   │                 │                  │                            │
-   │                 │── push ─────────▶│                            │
-   │                 │   { content,     │ verify signature OK        │
-   │                 │     signature }  │ latestContent = content    │
-   │                 │                  │                            │
-   │◀─── ready ──────│                  │                            │
-   │                 │                  │                            │
-   │ print "Join     https://.../#abc"  │                            │
-   │ print "Edit key ...(press c)..."   │                            │
-   │ print hint line                    │                            │
-   │                 │                  │                            │
-   │                                    │                            │
-   │                                    │◀── WebSocket ──────────────│
-   │                                    │ onConnect                  │
-   │                                    │   guestId++                │
-   │                                    │── init ───────────────────▶│
-   │                                    │   hasSharer: true          │
-   │                                    │   content: "..."           │
-   │                                    │   publicKey: X             │
-   │                                    │                          ✓ Live
+  ┌─────────┐              ┌─────────┐              ┌─────────┐
+  │  Local   │    signed    │  Relay  │   updates    │ Remote  │
+  │  File    │────pushes───▶│ (Cloud) │─────────────▶│ Viewers │
+  │          │◀──verified───│         │◀──signed─────│         │
+  └─────────┘   WebSocket   └─────────┘  WebSocket   └─────────┘
+     CLI                    PartyKit /                Browser or
+     watcher               Cloudflare                  another
+                             Workers                     CLI
 ```
 
-**Key property: the Join URL is never printed before the relay has acknowledged the sharer.** The user cannot see or share the URL until the room is fully established. This eliminates the race where a viewer arrives before the sharer.
+Three components. All communication is via WebSocket. The relay is stateful per room (tracks who's sharing, verifies signatures, broadcasts updates). Everything else is stateless.
 
-## Browser state machine
+| Component | Code | Runtime | Crypto |
+|-----------|------|---------|--------|
+| **CLI + Watcher** | `src/cli.ts`, `src/watcher.ts` | Node.js | tweetnacl |
+| **Relay** | `src/party/livedown.ts` | Cloudflare Workers (PartyKit) | @noble/curves |
+| **Browser Viewer** | `public/index.html` | Browser | tweetnacl (CDN) |
+
+## Journeys
+
+### Journey 1: Share (CLI → Web)
+
+The sharer runs `livedown share ./file.md`. A viewer opens the URL in a browser.
 
 ```
-               ┌────────────┐
-               │  Loading   │   initial state, websocket opening
-               └─────┬──────┘
-                     │ init arrives
-                     │
-              ┌──────┴──────┐
-              │             │
-          hasSharer?    hasSharer?
-             true          false
-              │             │
-              ▼             ▼
-       ┌──────────┐   ┌───────────┐
-       │   Live   │   │ NotFound  │
-       └────┬─────┘   └─────┬─────┘
-            │               │
-            │sharer-gone    │sharer-here
-            │               │
-            ▼               ▼
-       ┌──────────┐   ┌──────────┐
-       │ Offline  │──▶│   Live   │
-       └──────────┘   └──────────┘
-            ▲              │
-            │sharer-here   │sharer-gone
-            └──────────────┘
+  Terminal                           Cloud                         Browser
+  ────────                           ─────                         ───────
+
+  $ livedown share ./file.md
+  │
+  │ generate Ed25519 keypair
+  │ print "Watching ./file.md"
+  │ print "Connecting..."
+  │
+  │ startWatcher()
+  │         │
+  │         │──── WebSocket ────────▶ Relay
+  │         │                         │ onConnect
+  │         │◀──── init ──────────────│
+  │         │                         │
+  │         │──── set-token ─────────▶│
+  │         │     { publicKey }       │ sharers.add(conn)
+  │         │◀──── sharer-ack ───────│
+  │         │                         │
+  │         │──── push ──────────────▶│
+  │         │     { content,          │ verify sig ✓
+  │         │       signature }       │ store content
+  │         │                         │
+  │◀── ready                          │
+  │                                   │
+  │ print "Join  https://.../#abc"    │
+  │ print "Edit key  f7a2c9e1..."     │
+  │ print "o open  c copy  q quit"    │
+  │                                   │
+  │                                   │         User opens URL
+  │                                   │◀──────── WebSocket ────────── │
+  │                                   │ onConnect                     │
+  │                                   │──────── init ────────────────▶│
+  │                                   │  hasSharer: true              │
+  │                                   │  content: "..."               │
+  │                                   │  publicKey: X                 │
+  │                                   │                            ✓ Live
+  │                                   │                            Content
+  │                                   │                            renders
 ```
 
-### State descriptions
+**Key property:** the Join URL is never printed before the relay confirms the sharer is registered (`sharer-ack`). The viewer can never arrive at an empty room via a freshly printed URL.
 
-| State     | What the user sees                                                    | Edits allowed? |
-|-----------|-----------------------------------------------------------------------|----------------|
-| Loading   | Spinner, "Connecting..."                                              | No             |
-| Live      | Status bar, editor, preview, last known content                       | If unlocked    |
-| Offline   | Status bar with "sharer offline" indicator, editor in read-only mode, last known content still visible | No             |
-| NotFound  | Landing page with "not found — no one is sharing this document"       | No             |
+### Journey 2: Edit Live (CLI → Web ← Edit Online)
 
-### Transitions
+A viewer with the edit key makes changes in the browser. The sharer's local file is updated.
 
-| From      | Event                  | To        | Why |
-|-----------|------------------------|-----------|-----|
-| Loading   | `init hasSharer:true`  | Live      | Sharer was already registered |
-| Loading   | `init hasSharer:false` | NotFound  | First init, no sharer; ghost room |
-| NotFound  | `sharer-here`          | Live      | User started CLI after opening browser |
-| Live      | `sharer-gone`          | Offline   | Sharer disconnected (maybe temporarily) |
-| Live      | `init hasSharer:false` | Offline   | Viewer's own ws reconnected and sharer isn't there right now — *not* NotFound, because we've seen a sharer before |
-| Live      | `init hasSharer:true`  | Live      | Viewer's own ws reconnected, sharer still there |
-| Offline   | `sharer-here`          | Live      | Sharer reconnected (CLI restart, network blip) |
-| Offline   | `init hasSharer:true`  | Live      | Viewer's ws reconnected and sharer is already back |
+```
+  Terminal               Cloud                    Browser
+  ────────               ─────                    ───────
 
-**Rule: NotFound is only reachable from Loading.** Once a viewer has been Live, they can never return to NotFound — only to Offline. Transitioning back to the landing page after the user has been editing would discard their session and be a bad UX. The Offline state keeps content visible, disables editing, and recovers automatically when the sharer returns.
+  (watching ./file.md)    (room live)              (viewing, read-only)
+  │                       │                        │
+  │                       │                        │ User clicks
+  │                       │                        │ "Enter Edit Key"
+  │                       │                        │
+  │                       │                        │ Pastes edit key
+  │                       │                        │ (64 hex chars)
+  │                       │                        │
+  │                       │                        │ Browser derives
+  │                       │                        │ keypair from seed,
+  │                       │                        │ verifies public key
+  │                       │                        │ matches room's
+  │                       │                        │
+  │                       │                        │ ✓ Editor unlocked
+  │                       │                        │
+  │                       │                        │ User types in
+  │                       │                        │ CodeMirror editor
+  │                       │                        │ (400ms debounce)
+  │                       │                        │
+  │                       │◀──── push ─────────────│
+  │                       │  { content: "new text", │
+  │                       │    signature: "abc..." } │
+  │                       │                        │
+  │                       │ verify sig ✓           │
+  │                       │ store content          │
+  │                       │                        │
+  │                       │──── update ───────────▶│ (other viewers)
+  │◀──── update ──────────│  { content, sig }      │
+  │  { content,           │                        │
+  │    signature }        │                        │
+  │                       │                        │
+  │ verify sig ✓          │                        │
+  │ write to ./file.md    │                        │
+  │                       │                        │
+  │  dave  new text...    │                        │
+  │                       │                        │
 
-**No timeouts anywhere.** Every transition is triggered by an explicit relay message. The browser never guesses.
-
-## Why the old approach was broken
-
-The old code tried to infer presence from **content**:
-
-```js
-if (msg.content) gotContent = true;
-// ... 8 seconds later ...
-if (!gotContent) showNotFound();
+  Wrong key? ──────────────────────────────────────│
+  │                       │◀──── push (bad sig) ───│
+  │                       │ verify sig ✗           │
+  │                       │──── auth-error ───────▶│ Modal shows error
+  │  ✗ Guest 3 — rejected │──── auth-rejected ────▶│ (other viewers)
 ```
 
-This broke because:
-1. **Empty documents look identical to no-sharer rooms.** A new blank file is a perfectly valid thing to share.
-2. **Content is not a presence signal.** The relay can have a sharer without any content yet (initial push hasn't arrived).
-3. **Timeouts guess.** An 8-second wait is both too long (bad UX for genuine not-found) and too short (bad UX for slow networks).
+**Three verification points:** the relay verifies before broadcasting, the watcher verifies before writing to disk, and the browser verifies the public key on entry. Even a compromised relay cannot forge updates that the watcher accepts.
 
-The structural fix replaces content inference with explicit relay state:
-- Relay tracks sharers as a `Set<string>` of connection IDs
-- `init` message carries an authoritative `hasSharer: boolean` flag
-- `sharer-here` / `sharer-gone` broadcasts handle live transitions
+### Journey 3: Share to Remote Machine (Future — In Progress)
 
-## Message types
+Two people share a file across machines. One is the leader, the other joins and gets a local copy.
 
-### Sharer → Relay
+```
+  Machine A                Cloud                    Machine B
+  ─────────                ─────                    ─────────
+
+  $ livedown share ./notes.md
+  │                         │
+  │ (same as Journey 1)     │
+  │ ...                     │
+  │ print Join URL          │
+  │ print Edit key          │
+  │                         │
+  │ Share URL + edit key    │                        │
+  │ with Machine B          │                        │
+  │ (via Slack, email...)   │                        │
+  │                         │                        │
+  │                         │            $ livedown join <url>
+  │                         │                --edit-key <key>
+  │                         │                        │
+  │                         │◀─── WebSocket ─────────│
+  │                         │──── init ─────────────▶│
+  │                         │  content: "..."        │
+  │                         │                        │
+  │                         │◀─── set-token ─────────│
+  │                         │  sharers.add(B)        │
+  │                         │──── sharer-ack ───────▶│
+  │                         │                        │
+  │                         │                        │ write content to
+  │                         │                        │ ./local-notes.md
+  │                         │                        │
+  │                         │                        │ watch local file
+  │                         │                        │
+  │ User A edits            │                        │
+  │ ./notes.md              │                        │
+  │                         │                        │
+  │──── push ──────────────▶│                        │
+  │                         │ verify ✓               │
+  │                         │──── update ───────────▶│
+  │                         │                        │ verify ✓
+  │                         │                        │ write to local file
+  │                         │                        │
+  │                         │               User B edits
+  │                         │               ./local-notes.md
+  │                         │                        │
+  │                         │◀──── push ─────────────│
+  │                         │ verify ✓               │
+  │◀──── update ────────────│                        │
+  │ verify ✓                │                        │
+  │ write to ./notes.md     │                        │
+  │                         │                        │
+  │ Both machines in sync   │    Both machines in sync
+```
+
+**Status:** not yet implemented. Requires a `livedown join` command that downloads content, creates a local file, and starts a watcher in the reverse direction. The `sharers: Set` in the relay already supports multiple sharers — no relay changes needed.
+
+## Browser State Machine
+
+```
+            ┌────────────┐
+            │  Loading   │   spinner visible, ws connecting
+            └─────┬──────┘
+                  │ init arrives
+                  │
+           ┌──────┴──────┐
+           │             │
+       hasSharer      hasSharer
+         true           false
+           │             │
+           ▼             ▼
+    ┌──────────┐   ┌───────────┐
+    │   Live   │   │ NotFound  │
+    └────┬─────┘   └─────┬─────┘
+         │               │
+         │sharer-gone    │sharer-here
+         │               │
+         ▼               ▼
+    ┌──────────┐   ┌──────────┐
+    │ Offline  │──▶│   Live   │
+    └──────────┘   └──────────┘
+         ▲              │
+         │sharer-here   │sharer-gone
+         └──────────────┘
+```
+
+| State     | UI | Edits? |
+|-----------|----|--------|
+| Loading   | Spinner, "Connecting..." | No |
+| Live      | Editor + preview, status bar shows "live" | If edit key entered |
+| Offline   | Same UI, status bar shows "sharer offline", editor read-only | No |
+| NotFound  | Landing page, "no one is sharing this document" | No |
+
+**Rule:** NotFound is only reachable from Loading. Once Live, the viewer can only go to Offline (recoverable), never back to the landing page.
+
+## Message Types
+
+### Client → Relay
+
+| Type | Fields | Sent by |
+|------|--------|---------|
+| `set-token` | `publicKey` | Sharer (on connect) |
+| `push` | `content`, `signature`, `meta` | Sharer or unlocked viewer |
+
+### Relay → Sender only
+
+| Type | Purpose |
+|------|---------|
+| `sharer-ack` | set-token accepted; CLI prints URL |
+| `auth-error` | push rejected (bad signature) |
+
+### Relay → All (broadcast)
 
 | Type | Fields | Purpose |
 |------|--------|---------|
-| `set-token` | `publicKey` | Register as a sharer. Relay adds connection to `sharers` and stores the public key (first one wins; subsequent messages must match). |
-| `push` | `content`, `signature`, `meta` | Push new content. Signature must be valid against the stored public key. |
+| `init` | `content`, `meta`, `guestId`, `hasSharer`, `protected`, `publicKey` | Sent to each connection on connect |
+| `update` | `content`, `meta`, `signature` | After a valid push |
+| `sharer-here` | `protected`, `publicKey` | Sharer joined an empty room |
+| `sharer-gone` | — | Last sharer disconnected |
+| `auth-rejected` | `editor` | Someone's push was rejected (info for sharer) |
 
-### Relay → Sharer only
+## Security
 
-| Type | Fields | Purpose |
-|------|--------|---------|
-| `sharer-ack` | — | Confirms the `set-token` was accepted. CLI waits for this before printing the Join URL. |
-| `auth-error` | — | Your push was rejected (bad signature). |
+See [Security Principles](../.claude/agents/security.md) for the full set of rules.
 
-### Relay → Viewer broadcasts
+- **Ed25519 signing** — pushes are signed with the edit key (private), verified with the public key
+- **Defense in depth** — relay verifies before broadcasting; watcher verifies before writing to disk
+- **URLs are locators, not credentials** — the viewer URL is safe to share publicly
+- **No custom crypto** — tweetnacl (Node/browser) and @noble/curves (relay) only
 
-| Type | Fields | Purpose |
-|------|--------|---------|
-| `init` | `content`, `meta`, `guestId`, `hasSharer`, `protected`, `publicKey` | Sent once per connection, immediately on connect. |
-| `update` | `content`, `meta`, `signature` | Broadcast after a valid push. |
-| `sharer-here` | `protected`, `publicKey` | Broadcast when a sharer joins an empty room. Viewers in `NotFound` or `Offline` transition to `Live`. |
-| `sharer-gone` | — | Broadcast when the last sharer disconnects. Viewers in `Live` transition to `Offline`. |
-| `auth-rejected` | `editor` | Information for the sharer: someone else tried to push with a bad key. |
+## What Must Stay in Sync
 
-## Security model
+Any PR that changes the protocol, message types, or state transitions must update:
 
-See also [Security](../README.md#security) in the README.
-
-- **Ed25519 keypairs**: the CLI generates a 32-byte seed (the "edit key"). The public key is sent to the relay via `set-token`. The private key stays with the sharer and any authorized editors.
-- **Defense in depth**: the relay verifies signatures before broadcasting; the watcher verifies signatures before writing to disk. A compromised relay cannot forge updates.
-- **URLs are locators, not credentials**: the viewer URL is safe to share publicly. Editing requires the edit key, which is entered out-of-band (pasted into the browser modal or shared through a trusted channel).
-- **Never implement cryptographic code**: `tweetnacl` in Node and browser, `@noble/curves` in the relay (PartyKit bundler can't handle tweetnacl's optional `require('crypto')`). Both implement RFC 8032 Ed25519 and produce interchangeable signatures.
-
-## Edge cases
-
-### Viewer arrives before sharer
-Impossible in the happy path — the CLI doesn't print the URL until `sharer-ack` arrives. If the user saves the URL from a previous session and visits it, they land in `NotFound`. If they then start the CLI, they get `sharer-here` and transition to `Live`.
-
-### Sharer disconnects mid-session
-Relay calls `onClose`, removes from `sharers`, broadcasts `sharer-gone`. Viewers enter `Offline`. The editor becomes read-only but the last known content stays visible. When the CLI reconnects (manual restart or automatic reconnect loop), the new `set-token` triggers `sharer-here` and viewers return to `Live`.
-
-### CLI network blip (Wi-Fi dropped briefly)
-Watcher's WebSocket closes, reconnects after 2s. Relay sees disconnect → `sharer-gone`. Reconnect → new `set-token` → `sharer-here`. Viewers briefly see `Offline` then return to `Live`. Content is not lost; any edits made during the blip are pushed as soon as the connection is re-established.
-
-### Multiple sharers (future)
-Already supported by the `sharers: Set<string>`. Two CLIs can run against the same room (same public key) and both are counted as sharers. `hasSharer` stays true as long as at least one is connected.
-
-### Empty document
-`latestContent === ""` is valid. `hasSharer` is independent of content. The viewer enters `Live` with an empty editor.
-
-### Ghost rooms (old URL, no sharer)
-`init.hasSharer: false` immediately. Viewer goes straight to `NotFound`. No timeout involved.
-
-## What must be kept in sync with this document
-
-- `src/party/livedown.ts` — roles, message types, state transitions
-- `src/watcher.ts` — sharer connection lifecycle, `sharer-ack` handling
-- `src/cli.ts` — when the URL is printed (must be after ready)
-- `public/index.html` — browser state machine, message handling
-- `README.md` "How It Works" section — user-facing summary
-
-If you change any of these, update this document in the same PR.
+- This document (`docs/architecture.md`)
+- `README.md` "How It Works" section
+- `CLAUDE.md` architecture references

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,13 @@ import prettier from "eslint-plugin-prettier";
 
 export default [
   {
-    ignores: ["dist/", "node_modules/", "public/", "jest.config.ts"],
+    ignores: [
+      "dist/",
+      "node_modules/",
+      "public/",
+      "scratch/",
+      "jest.config.ts",
+    ],
   },
   ...tseslint.configs.recommended,
   {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from "jest";
 const config: Config = {
   preset: "ts-jest",
   testEnvironment: "node",
-  roots: ["<rootDir>/src"],
+  roots: ["<rootDir>/src", "<rootDir>/tests"],
   testMatch: ["**/*.test.ts"],
   collectCoverageFrom: ["src/**/*.ts", "!src/**/*.test.ts"],
 };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,12 @@ const config: Config = {
   roots: ["<rootDir>/src", "<rootDir>/tests"],
   testMatch: ["**/*.test.ts"],
   collectCoverageFrom: ["src/**/*.ts", "!src/**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      { diagnostics: { ignoreCodes: [151002] } },
+    ],
+  },
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "livedown": "dist/cli.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x dist/cli.js",
     "build:watch": "tsc -w",
     "dev": "tsx watch src/cli.ts",
     "start": "ts-node ./src/cli.ts",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:fix": "eslint --fix .",
     "test": "jest --no-coverage --testPathIgnorePatterns=integration",
     "test:integration": "jest --no-coverage --forceExit --testPathPatterns=integration",
+    "test:integration:watch": "LIVEDOWN_OPEN_BROWSER=1 jest --no-coverage --forceExit --testPathPatterns=integration",
     "test:all": "jest --no-coverage",
     "test:cov": "jest --coverage --testPathIgnorePatterns=integration",
     "prepare": "husky"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "start": "ts-node ./src/cli.ts",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "test": "jest --no-coverage",
-    "test:cov": "jest --coverage",
+    "test": "jest --no-coverage --testPathIgnorePatterns=integration",
+    "test:integration": "jest --no-coverage --forceExit --testPathPatterns=integration",
+    "test:all": "jest --no-coverage",
+    "test:cov": "jest --coverage --testPathIgnorePatterns=integration",
     "prepare": "husky"
   },
   "files": [

--- a/partykit.json
+++ b/partykit.json
@@ -2,5 +2,9 @@
   "name": "livedown",
   "main": "src/party/livedown.ts",
   "compatibilityDate": "2025-01-01",
-  "serve": "public"
+  "serve": {
+    "path": "public",
+    "browserTTL": 0,
+    "edgeTTL": 0
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -683,7 +683,10 @@
     recordEdit(myGuestName, new Date().toISOString(), content);
   }
 
-  var gotContent = false;
+  function showNotFound() {
+    var name = docName.split('/').pop() || docName;
+    showLanding(name + ' not found — no one is sharing this document. See below to get started.');
+  }
 
   function connect() {
     ws = new WebSocket(url);
@@ -699,11 +702,11 @@
 
       if (msg.type === 'init') {
         setProfile(msg.guestId);
-        // Treat any of these as proof that someone is sharing this document:
-        // - content exists
-        // - room is protected (someone registered a public key)
-        // - meta has an editor (someone has pushed at least once)
-        if (msg.content || msg.protected || msg.meta?.editor) gotContent = true;
+        // Authoritative signal from the relay: is there a sharer present?
+        if (!msg.hasSharer) {
+          showNotFound();
+          return;
+        }
         if (msg.content) {
           cm.setValue(msg.content);
           renderPreview(msg.content);
@@ -718,8 +721,6 @@
       }
 
       if (msg.type === 'update') {
-        gotContent = true;
-
         setMeta(msg.meta);
         setLastEdit(msg.meta?.editor, msg.meta?.editedAt);
         recordEdit(msg.meta?.editor, msg.meta?.editedAt, msg.content);
@@ -731,6 +732,7 @@
         } else {
           flashRemoteEdit();
         }
+        return;
       }
 
       if (msg.type === 'auth-error') {
@@ -744,11 +746,16 @@
         return;
       }
 
-      if (msg.type === 'protected') {
+      if (msg.type === 'sharer-here') {
         isProtected = !!msg.protected;
-        if (msg.protected) gotContent = true;
         if (msg.publicKey) roomPublicKey = msg.publicKey;
         updateProfileAccess();
+        return;
+      }
+
+      if (msg.type === 'sharer-gone') {
+        showNotFound();
+        return;
       }
     };
 
@@ -760,14 +767,6 @@
   }
 
   connect();
-
-  // Show not-found if no content arrives within 8s
-  setTimeout(function () {
-    if (!gotContent) {
-      var name = docName.split('/').pop() || docName;
-      showLanding(name + ' not found — no one is sharing this document. See below to get started.');
-    }
-  }, 8000);
 
   // ── Draggable divider ────────────────────────────────────────
   const divider     = document.getElementById('divider');

--- a/public/index.html
+++ b/public/index.html
@@ -671,6 +671,7 @@
       editKey = val;
       secretKey = kp.secretKey;
       editUnlocked = true;
+      cm.setOption('readOnly', false);
       updateProfileAccess();
       hideTokenModal();
     } catch (e) {

--- a/public/index.html
+++ b/public/index.html
@@ -427,9 +427,11 @@
     if (newState === 'live') {
       hasEverBeenLive = true;
       setStatus('live');
-      // Re-apply edit lock if the room is protected and unlocked state is unknown
+      // Never use readOnly in live state - the beforeChange handler blocks
+      // edits and shows the edit key modal for protected rooms. readOnly
+      // silently swallows input so the user never sees the modal.
       if (typeof cm !== 'undefined') {
-        cm.setOption('readOnly', isProtected && !editUnlocked);
+        cm.setOption('readOnly', false);
         cm.refresh();
       }
     }

--- a/public/index.html
+++ b/public/index.html
@@ -699,7 +699,11 @@
 
       if (msg.type === 'init') {
         setProfile(msg.guestId);
-        if (msg.content) gotContent = true;
+        // Treat any of these as proof that someone is sharing this document:
+        // - content exists
+        // - room is protected (someone registered a public key)
+        // - meta has an editor (someone has pushed at least once)
+        if (msg.content || msg.protected || msg.meta?.editor) gotContent = true;
         if (msg.content) {
           cm.setValue(msg.content);
           renderPreview(msg.content);
@@ -742,6 +746,7 @@
 
       if (msg.type === 'protected') {
         isProtected = !!msg.protected;
+        if (msg.protected) gotContent = true;
         if (msg.publicKey) roomPublicKey = msg.publicKey;
         updateProfileAccess();
       }

--- a/public/index.html
+++ b/public/index.html
@@ -367,17 +367,67 @@
     })
     .catch(function() {});
 
-  function showLanding(errorMsg) {
-    document.getElementById('landing').style.display = 'block';
-    document.getElementById('statusbar').style.display = 'none';
-    document.getElementById('panes').style.display = 'none';
-    document.getElementById('edits-popover').style.display = 'none';
-    document.title = 'livedown';
-    if (errorMsg) {
-      var el = document.getElementById('landing-error');
-      el.textContent = errorMsg;
-      el.classList.add('visible');
+  // ── App state machine ───────────────────────────────────────
+  // States: 'loading' | 'live' | 'offline' | 'notfound'
+  // Transitions are driven entirely by relay messages — no timeouts.
+  var appState = 'loading';
+
+  function setAppState(newState, errorMsg) {
+    appState = newState;
+    var landing = document.getElementById('landing');
+    var statusbar = document.getElementById('statusbar');
+    var panes = document.getElementById('panes');
+    var editsPopover = document.getElementById('edits-popover');
+    var landingError = document.getElementById('landing-error');
+
+    if (newState === 'notfound') {
+      landing.style.display = 'block';
+      statusbar.style.display = 'none';
+      panes.style.display = 'none';
+      editsPopover.style.display = 'none';
+      document.title = 'livedown';
+      if (errorMsg) {
+        landingError.textContent = errorMsg;
+        landingError.classList.add('visible');
+      }
+      return;
     }
+
+    // live / offline / loading — show the main UI
+    landing.style.display = 'none';
+    statusbar.style.display = '';
+    panes.style.display = '';
+    editsPopover.style.display = '';
+    landingError.classList.remove('visible');
+
+    if (newState === 'loading') {
+      setStatus('connecting');
+      return;
+    }
+
+    if (newState === 'offline') {
+      // Sharer disconnected — keep last known content visible but disable editing
+      setStatus('offline');
+      if (typeof cm !== 'undefined') {
+        cm.setOption('readOnly', true);
+        cm.refresh();
+      }
+      return;
+    }
+
+    if (newState === 'live') {
+      setStatus('live');
+      // Re-apply edit lock if the room is protected and unlocked state is unknown
+      if (typeof cm !== 'undefined') {
+        cm.setOption('readOnly', isProtected && !editUnlocked);
+        cm.refresh();
+      }
+    }
+  }
+
+  // Back-compat alias: older code called showLanding() with no hash.
+  function showLanding(errorMsg) {
+    setAppState('notfound', errorMsg);
   }
 
   // No hash — show landing page
@@ -514,8 +564,13 @@
   const label = document.getElementById('sb-label');
 
   function setStatus(state) {
-    dot.className   = state;
-    label.textContent = state === 'live' ? 'live' : state === 'offline' ? 'offline' : 'connecting…';
+    // states: 'live', 'offline' (sharer gone), 'disconnected' (ws lost), 'connecting'
+    dot.className = state === 'live' ? 'live' : state === 'connecting' ? '' : 'offline';
+    label.textContent =
+      state === 'live' ? 'live'
+      : state === 'offline' ? 'sharer offline'
+      : state === 'disconnected' ? 'disconnected'
+      : 'connecting…';
   }
 
   function setMeta(meta) {
@@ -683,18 +738,25 @@
     recordEdit(myGuestName, new Date().toISOString(), content);
   }
 
-  function showNotFound() {
+  function notFoundMessage() {
     var name = docName.split('/').pop() || docName;
-    showLanding(name + ' not found — no one is sharing this document. See below to get started.');
+    return name + ' not found — no one is sharing this document. See below to get started.';
+  }
+
+  function applySharerInfo(msg) {
+    isProtected = !!msg.protected;
+    if (msg.publicKey) roomPublicKey = msg.publicKey;
+    updateProfileAccess();
   }
 
   function connect() {
     ws = new WebSocket(url);
 
     ws.onopen = () => {
-      setStatus('live');
       reconnectDelay = 1000;
       document.getElementById('loading').classList.remove('active');
+      // Don't call setStatus('live') here — wait for init to tell us whether
+      // we're actually live (hasSharer:true) or in notfound (hasSharer:false).
     };
 
     ws.onmessage = (e) => {
@@ -702,21 +764,21 @@
 
       if (msg.type === 'init') {
         setProfile(msg.guestId);
-        // Authoritative signal from the relay: is there a sharer present?
-        if (!msg.hasSharer) {
-          showNotFound();
-          return;
-        }
         if (msg.content) {
           cm.setValue(msg.content);
           renderPreview(msg.content);
         }
         setMeta(msg.meta);
-        isProtected = !!msg.protected;
-        if (msg.publicKey) roomPublicKey = msg.publicKey;
-        updateProfileAccess();
+        applySharerInfo(msg);
         setLastEdit(msg.meta?.editor, msg.meta?.editedAt);
         if (msg.meta?.editor) recordEdit(msg.meta.editor, msg.meta.editedAt, msg.content);
+
+        // Authoritative: does the room have a sharer right now?
+        if (msg.hasSharer) {
+          setAppState('live');
+        } else {
+          setAppState('notfound', notFoundMessage());
+        }
         return;
       }
 
@@ -747,20 +809,24 @@
       }
 
       if (msg.type === 'sharer-here') {
-        isProtected = !!msg.protected;
-        if (msg.publicKey) roomPublicKey = msg.publicKey;
-        updateProfileAccess();
+        applySharerInfo(msg);
+        // Transition: notfound/offline → live
+        setAppState('live');
         return;
       }
 
       if (msg.type === 'sharer-gone') {
-        showNotFound();
+        // Don't kick the viewer to the landing page — the sharer might reconnect.
+        // Keep content visible but disable editing.
+        setAppState('offline');
         return;
       }
     };
 
     ws.onclose = () => {
-      setStatus('offline');
+      // Viewer's own WebSocket lost — this is different from the sharer going
+      // offline. Show "disconnected" until reconnect succeeds.
+      setStatus('disconnected');
       setTimeout(connect, reconnectDelay);
       reconnectDelay = Math.min(reconnectDelay * 2, 10000);
     };

--- a/public/index.html
+++ b/public/index.html
@@ -370,7 +370,13 @@
   // ── App state machine ───────────────────────────────────────
   // States: 'loading' | 'live' | 'offline' | 'notfound'
   // Transitions are driven entirely by relay messages — no timeouts.
+  //
+  // Rule: 'notfound' is only reachable from 'loading'. Once a viewer has
+  // seen a sharer (live state), subsequent disconnects transition to
+  // 'offline' instead — the content stays visible and a reconnecting
+  // sharer restores the session.
   var appState = 'loading';
+  var hasEverBeenLive = false;
 
   function setAppState(newState, errorMsg) {
     appState = newState;
@@ -379,12 +385,15 @@
     var panes = document.getElementById('panes');
     var editsPopover = document.getElementById('edits-popover');
     var landingError = document.getElementById('landing-error');
+    var tokenModal = document.getElementById('token-modal');
 
     if (newState === 'notfound') {
       landing.style.display = 'block';
       statusbar.style.display = 'none';
       panes.style.display = 'none';
       editsPopover.style.display = 'none';
+      // Close any open modal — it's meaningless when there's no sharer.
+      if (tokenModal) tokenModal.classList.remove('open');
       document.title = 'livedown';
       if (errorMsg) {
         landingError.textContent = errorMsg;
@@ -416,6 +425,7 @@
     }
 
     if (newState === 'live') {
+      hasEverBeenLive = true;
       setStatus('live');
       // Re-apply edit lock if the room is protected and unlocked state is unknown
       if (typeof cm !== 'undefined') {
@@ -777,7 +787,13 @@
         // Authoritative: does the room have a sharer right now?
         if (msg.hasSharer) {
           setAppState('live');
+        } else if (hasEverBeenLive) {
+          // Viewer reconnected and the sharer isn't currently present, but
+          // we've seen one before — this is the 'offline' state, not 'notfound'.
+          // The sharer may come back; keep content visible, disable editing.
+          setAppState('offline');
         } else {
+          // First init and no sharer — truly not found.
           setAppState('notfound', notFoundMessage());
         }
         return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,16 +54,34 @@ async function startSharing(
   const roomUrl = buildRoomUrl(opts.relay, doc);
 
   console.log(`\n  Watching  ${filePath}`);
+  // Show a transient "Connecting..." line that gets overwritten when the
+  // watcher is ready. The URL is only printed after the relay acks the sharer
+  // so the user can never share a URL before the room is fully established.
+  if (process.stdout.isTTY) {
+    process.stdout.write(`  \x1b[2mConnecting...\x1b[0m`);
+  } else {
+    console.log("  Connecting...");
+  }
+
+  try {
+    await startWatcher(filePath, doc, roomUrl, opts.editor, editKey, publicKey);
+  } catch (err) {
+    if (process.stdout.isTTY) process.stdout.write("\r\x1b[2K");
+    console.error(`  \x1b[31m✗ ${(err as Error).message}\x1b[0m`);
+    process.exit(1);
+  }
+
+  if (process.stdout.isTTY) process.stdout.write("\r\x1b[2K");
   console.log(
-    `  Join      \x1b[4m\x1b]8;;${viewerUrl}\x07${viewerUrl}\x1b]8;;\x07\x1b[24m`
+    `  Join      \x1b[4m\x1b]8;;${viewerUrl}\x07${viewerUrl}\x1b]8;;\x07\x1b[24m \x1b[2m(press o to open)\x1b[0m`
   );
   console.log(
     `  Edit key  \x1b[33m${editKey}\x1b[0m \x1b[2m(press c to copy)\x1b[0m\n`
   );
 
-  startWatcher(filePath, doc, roomUrl, opts.editor, editKey, publicKey);
-
   if (process.stdin.isTTY) {
+    const hints = "\x1b[2m  o open  c copy key  q quit\x1b[0m";
+    process.stdout.write(hints);
     process.stdin.setRawMode(true);
     process.stdin.resume();
     process.stdin.on("data", async (key: Buffer) => {
@@ -78,12 +96,27 @@ async function startSharing(
           process.stdout.write(
             "\x1b[2K\r  \x1b[32m✓ Edit key copied to clipboard\x1b[0m\n"
           );
-          process.stdout.write("\x1b[2m  c copy key  q quit\x1b[0m");
+          process.stdout.write(hints);
         } catch {
           process.stdout.write(
             "\x1b[2K\r  \x1b[31m✗ Could not copy to clipboard\x1b[0m\n"
           );
-          process.stdout.write("\x1b[2m  c copy key  q quit\x1b[0m");
+          process.stdout.write(hints);
+        }
+      }
+      if (ch === "o") {
+        try {
+          const open = (await import("open")).default;
+          await open(viewerUrl);
+          process.stdout.write(
+            "\x1b[2K\r  \x1b[32m✓ Opened in browser\x1b[0m\n"
+          );
+          process.stdout.write(hints);
+        } catch {
+          process.stdout.write(
+            "\x1b[2K\r  \x1b[31m✗ Could not open browser\x1b[0m\n"
+          );
+          process.stdout.write(hints);
         }
       }
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,22 +123,28 @@ program
   });
 
 function fileCompleter(line: string): [string[], string] {
-  // Resolve to absolute path for directory reads, but return relative matches
-  const input = line || ".";
+  // Determine the directory to list and the prefix to filter by.
+  // - Empty input → list current directory
+  // - Ends with "/" → list inside that directory
+  // - Otherwise → dirname/basename split
   let dir: string;
   let prefix: string;
+  let dirPart: string;
 
-  try {
-    const resolved = path.resolve(input);
-    if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
-      dir = resolved;
-      prefix = "";
-    } else {
-      dir = path.dirname(resolved);
-      prefix = path.basename(resolved);
-    }
-  } catch {
-    return [[], line];
+  if (!line) {
+    dir = ".";
+    dirPart = "";
+    prefix = "";
+  } else if (line.endsWith("/")) {
+    dir = line;
+    dirPart = line;
+    prefix = "";
+  } else {
+    dir = path.dirname(line) || ".";
+    dirPart = line.endsWith("/") ? line : path.dirname(line);
+    if (dirPart && !dirPart.endsWith("/")) dirPart += "/";
+    if (dirPart === "./") dirPart = "";
+    prefix = path.basename(line);
   }
 
   try {
@@ -148,13 +154,14 @@ function fileCompleter(line: string): [string[], string] {
       .map((e) => {
         try {
           const full = path.join(dir, e);
-          return fs.statSync(full).isDirectory() ? `${e}/` : e;
+          const suffix = fs.statSync(full).isDirectory() ? "/" : "";
+          return dirPart + e + suffix;
         } catch {
-          return e;
+          return dirPart + e;
         }
       })
       .sort();
-    return [matches, prefix];
+    return [matches, line];
   } catch {
     return [[], line];
   }
@@ -165,6 +172,7 @@ function promptForFile(): Promise<string> {
     const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,
+      terminal: true,
       completer: fileCompleter,
     });
     rl.question("File to share: ", (answer) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import readline from "readline";
 import { Command } from "commander";
 import { startWatcher } from "./watcher";
 import { generateEditKeyPair, publicKeyFromEditKey } from "./token";
@@ -56,25 +57,13 @@ async function startSharing(
   console.log(
     `  Join      \x1b[4m\x1b]8;;${viewerUrl}\x07${viewerUrl}\x1b]8;;\x07\x1b[24m`
   );
-  console.log(`  Edit key  \x1b[33m${editKey}\x1b[0m\n`);
+  console.log(
+    `  Edit key  \x1b[33m${editKey}\x1b[0m \x1b[2m(press c to copy)\x1b[0m\n`
+  );
 
   startWatcher(filePath, doc, roomUrl, opts.editor, editKey, publicKey);
 
   if (process.stdin.isTTY) {
-    const { confirm } = await import("@inquirer/prompts");
-    const shouldCopy = await confirm({
-      message: "Copy edit key to clipboard?",
-      default: true,
-    });
-    if (shouldCopy) {
-      try {
-        const { default: clipboardy } = await import("clipboardy");
-        await clipboardy.write(editKey);
-        console.log("  \x1b[32m✓ Edit key copied to clipboard\x1b[0m\n");
-      } catch {
-        console.log("  \x1b[31m✗ Could not copy to clipboard\x1b[0m\n");
-      }
-    }
     process.stdin.setRawMode(true);
     process.stdin.resume();
     process.stdin.on("data", async (key: Buffer) => {
@@ -82,19 +71,19 @@ async function startSharing(
       if (ch === "q" || ch === "\u0003") {
         process.exit(0);
       }
-      if (ch === "t") {
+      if (ch === "c") {
         try {
           const { default: clipboardy } = await import("clipboardy");
           await clipboardy.write(editKey);
-          console.log(
-            "\x1b[2K\r  \x1b[32m✓ Edit key copied to clipboard\x1b[0m"
+          process.stdout.write(
+            "\x1b[2K\r  \x1b[32m✓ Edit key copied to clipboard\x1b[0m\n"
           );
-          process.stdout.write("\x1b[2m  t copy edit key  q quit\x1b[0m");
+          process.stdout.write("\x1b[2m  c copy key  q quit\x1b[0m");
         } catch {
-          console.log(
-            "\x1b[2K\r  \x1b[31m✗ Could not copy to clipboard\x1b[0m"
+          process.stdout.write(
+            "\x1b[2K\r  \x1b[31m✗ Could not copy to clipboard\x1b[0m\n"
           );
-          process.stdout.write("\x1b[2m  t copy edit key  q quit\x1b[0m");
+          process.stdout.write("\x1b[2m  c copy key  q quit\x1b[0m");
         }
       }
     });
@@ -133,22 +122,76 @@ program
     await open(url);
   });
 
+function fileCompleter(line: string): [string[], string] {
+  // Resolve to absolute path for directory reads, but return relative matches
+  const input = line || ".";
+  let dir: string;
+  let prefix: string;
+
+  try {
+    const resolved = path.resolve(input);
+    if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
+      dir = resolved;
+      prefix = "";
+    } else {
+      dir = path.dirname(resolved);
+      prefix = path.basename(resolved);
+    }
+  } catch {
+    return [[], line];
+  }
+
+  try {
+    const entries = fs.readdirSync(dir);
+    const matches = entries
+      .filter((e) => e.startsWith(prefix))
+      .map((e) => {
+        try {
+          const full = path.join(dir, e);
+          return fs.statSync(full).isDirectory() ? `${e}/` : e;
+        } catch {
+          return e;
+        }
+      })
+      .sort();
+    return [matches, prefix];
+  } catch {
+    return [[], line];
+  }
+}
+
+function promptForFile(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      completer: fileCompleter,
+    });
+    rl.question("File to share: ", (answer) => {
+      rl.close();
+      const trimmed = answer.trim();
+      if (!trimmed) return reject(new Error("No file specified"));
+      if (!fs.existsSync(path.resolve(trimmed))) {
+        return reject(new Error(`File not found: ${trimmed}`));
+      }
+      resolve(trimmed);
+    });
+  });
+}
+
 // No subcommand — prompt for file path
 if (process.argv.length === 2) {
   (async () => {
-    const { input } = await import("@inquirer/prompts");
-    const file = await input({
-      message: "File to share:",
-      validate: (value) => {
-        if (!value.trim()) return "Please enter a file path";
-        if (!fs.existsSync(path.resolve(value.trim()))) return "File not found";
-        return true;
-      },
-    });
-    startSharing(file.trim(), {
-      relay: defaultRelay,
-      editor: defaultEditor,
-    });
+    try {
+      const file = await promptForFile();
+      await startSharing(file, {
+        relay: defaultRelay,
+        editor: defaultEditor,
+      });
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
   })();
 } else {
   program.parse();

--- a/src/party/livedown.ts
+++ b/src/party/livedown.ts
@@ -29,6 +29,9 @@ export default class LivedownRoom implements Party.Server {
   latestMeta: Record<string, string> = {};
   guestCounter = 0;
   publicKey: string | undefined = undefined;
+  // Connection IDs that have registered as sharers via set-token.
+  // hasSharer = sharers.size > 0. Authoritative signal to viewers.
+  sharers = new Set<string>();
 
   constructor(readonly room: Party.Room) {}
 
@@ -43,25 +46,44 @@ export default class LivedownRoom implements Party.Server {
         content: this.latestContent,
         meta: this.latestMeta,
         guestId: this.guestCounter,
+        hasSharer: this.sharers.size > 0,
         protected: !!this.publicKey,
         publicKey: this.publicKey || null,
       })
     );
   }
 
+  onClose(conn: Party.Connection) {
+    if (this.sharers.delete(conn.id) && this.sharers.size === 0) {
+      // Last sharer disconnected — notify all remaining viewers
+      this.room.broadcast(JSON.stringify({ type: "sharer-gone" }));
+    }
+  }
+
   async onMessage(message: string, sender: Party.Connection) {
     try {
       const msg = JSON.parse(message);
 
-      if (msg.type === "set-token" && !this.publicKey && msg.publicKey) {
-        this.publicKey = msg.publicKey;
-        this.room.broadcast(
-          JSON.stringify({
-            type: "protected",
-            protected: true,
-            publicKey: this.publicKey,
-          })
-        );
+      if (msg.type === "set-token" && msg.publicKey) {
+        // First sharer registers the public key. Subsequent set-token
+        // messages with a matching key are accepted (reconnect / multi-sharer);
+        // mismatched keys are rejected.
+        if (!this.publicKey) {
+          this.publicKey = msg.publicKey;
+        } else if (this.publicKey !== msg.publicKey) {
+          return;
+        }
+        const wasEmpty = this.sharers.size === 0;
+        this.sharers.add(sender.id);
+        if (wasEmpty) {
+          this.room.broadcast(
+            JSON.stringify({
+              type: "sharer-here",
+              protected: true,
+              publicKey: this.publicKey,
+            })
+          );
+        }
         return;
       }
 

--- a/src/party/livedown.ts
+++ b/src/party/livedown.ts
@@ -75,13 +75,16 @@ export default class LivedownRoom implements Party.Server {
         }
         const wasEmpty = this.sharers.size === 0;
         this.sharers.add(sender.id);
+        // Acknowledge to the sender so the CLI can proceed to print the URL.
+        sender.send(JSON.stringify({ type: "sharer-ack" }));
         if (wasEmpty) {
           this.room.broadcast(
             JSON.stringify({
               type: "sharer-here",
               protected: true,
               publicKey: this.publicKey,
-            })
+            }),
+            [sender.id]
           );
         }
         return;

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -31,7 +31,7 @@ function parseMeta(
   };
 }
 
-const HINTS = "\x1b[2m  c copy key  q quit\x1b[0m";
+const HINTS = "\x1b[2m  o open  c copy key  q quit\x1b[0m";
 let showHints = false;
 
 function log(msg: string): void {
@@ -51,10 +51,28 @@ export function startWatcher(
   editor: string,
   editKey: string,
   publicKey: string
-): void {
+): Promise<void> {
   let ws: WebSocket | null = null;
   let ignoreNextWrite = false;
+  let isReady = false;
+  let resolveReady: (() => void) | null = null;
+  let rejectReady: ((err: Error) => void) | null = null;
   showHints = process.stdin.isTTY === true;
+
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+
+  const readyTimeout = setTimeout(() => {
+    if (!isReady && rejectReady) {
+      rejectReady(
+        new Error(
+          "Timed out connecting to relay after 10s. Check your network connection and relay host."
+        )
+      );
+    }
+  }, 10000);
 
   function push(raw: string): void {
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
@@ -79,7 +97,10 @@ export function startWatcher(
     ws = new WebSocket(roomUrl);
 
     ws.on("open", () => {
-      log("Connected to room");
+      // On first connect this is silent; the CLI shows "Connecting..." until
+      // sharer-ack resolves the ready promise. On subsequent reconnects we log
+      // so the user knows we recovered.
+      if (isReady) log("Reconnected to room");
       ws!.send(JSON.stringify({ type: "set-token", publicKey }));
       push(fs.readFileSync(filePath, "utf8"));
     });
@@ -87,6 +108,14 @@ export function startWatcher(
     ws.on("message", (data: WebSocket.Data) => {
       try {
         const msg = JSON.parse(data.toString());
+        if (msg.type === "sharer-ack") {
+          if (!isReady) {
+            isReady = true;
+            clearTimeout(readyTimeout);
+            resolveReady?.();
+          }
+          return;
+        }
         if (msg.type === "auth-error") {
           log("Edit key rejected — check your --edit-key value");
           return;
@@ -142,11 +171,19 @@ export function startWatcher(
     });
 
     ws.on("close", () => {
-      log("Disconnected — reconnecting in 2s...");
-      setTimeout(connect, 2000);
+      if (isReady) {
+        log("Disconnected — reconnecting in 2s...");
+        setTimeout(connect, 2000);
+      }
+      // If not yet ready, the readyTimeout will reject the promise; no reconnect.
     });
 
-    ws.on("error", (e: Error) => log(`WS error: ${e.message}`));
+    ws.on("error", (e: Error) => {
+      if (isReady) {
+        log(`WS error: ${e.message}`);
+      }
+      // Before ready, errors are reported via the rejected ready promise.
+    });
   }
 
   chokidar
@@ -164,4 +201,5 @@ export function startWatcher(
     });
 
   connect();
+  return ready;
 }

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -31,7 +31,7 @@ function parseMeta(
   };
 }
 
-const HINTS = "\x1b[2m  t copy edit key  q quit\x1b[0m";
+const HINTS = "\x1b[2m  c copy key  q quit\x1b[0m";
 let showHints = false;
 
 function log(msg: string): void {
@@ -80,9 +80,6 @@ export function startWatcher(
 
     ws.on("open", () => {
       log("Connected to room");
-      if (showHints && process.stdout.isTTY) {
-        process.stdout.write(HINTS);
-      }
       ws!.send(JSON.stringify({ type: "set-token", publicKey }));
       push(fs.readFileSync(filePath, "utf8"));
     });

--- a/tests/documents/empty.md
+++ b/tests/documents/empty.md
@@ -1,0 +1,14 @@
+# Empty file
+
+Test 2
+
+- bullet 1
+- bullet 2
+
+
+# Empty file
+
+Test 2
+
+- bullet 1
+- bullet 2

--- a/tests/integration/share-and-view.test.ts
+++ b/tests/integration/share-and-view.test.ts
@@ -122,10 +122,15 @@ function waitForFileContent(
 
 const OPEN_BROWSER = process.env.LIVEDOWN_OPEN_BROWSER === "1";
 
-async function openInBrowser(url: string): Promise<void> {
+function openInBrowser(url: string): void {
   if (!OPEN_BROWSER) return;
-  const open = (await import("open")).default;
-  await open(url);
+  const cmd =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "start"
+        : "xdg-open";
+  spawn(cmd, [url], { detached: true, stdio: "ignore" }).unref();
 }
 
 describe("integration: share and view", () => {
@@ -149,14 +154,14 @@ describe("integration: share and view", () => {
 
   it("share: CLI connects to relay and prints join info", async () => {
     cli = await startCli();
-    await openInBrowser(cli.viewerUrl);
+    openInBrowser(cli.viewerUrl);
     expect(cli.editKey).toMatch(/^[a-f0-9]{64}$/);
     expect(cli.roomUrl).toContain("livedown.dwmkerr.partykit.dev");
   });
 
   it("view: viewer connects and receives init with sharer present", async () => {
     cli = await startCli();
-    await openInBrowser(cli.viewerUrl);
+    openInBrowser(cli.viewerUrl);
     viewer = await connectViewer(cli.roomUrl);
     const init = await waitForMessage(viewer, "init");
     expect(init.hasSharer).toBe(true);
@@ -166,7 +171,7 @@ describe("integration: share and view", () => {
 
   it("edit rejected: unsigned push returns auth-error", async () => {
     cli = await startCli();
-    await openInBrowser(cli.viewerUrl);
+    openInBrowser(cli.viewerUrl);
     viewer = await connectViewer(cli.roomUrl);
     await waitForMessage(viewer, "init");
 
@@ -184,7 +189,7 @@ describe("integration: share and view", () => {
 
   it("edit online: signed push updates the local file", async () => {
     cli = await startCli();
-    await openInBrowser(cli.viewerUrl);
+    openInBrowser(cli.viewerUrl);
     viewer = await connectViewer(cli.roomUrl);
     await waitForMessage(viewer, "init");
 
@@ -205,7 +210,7 @@ describe("integration: share and view", () => {
 
   it("edit local: file change on disk is pushed to viewer", async () => {
     cli = await startCli();
-    await openInBrowser(cli.viewerUrl);
+    openInBrowser(cli.viewerUrl);
     viewer = await connectViewer(cli.roomUrl);
     await waitForMessage(viewer, "init");
 
@@ -219,7 +224,7 @@ describe("integration: share and view", () => {
 
   it("close: killing the CLI sends sharer-gone", async () => {
     cli = await startCli();
-    await openInBrowser(cli.viewerUrl);
+    openInBrowser(cli.viewerUrl);
     viewer = await connectViewer(cli.roomUrl);
     await waitForMessage(viewer, "init");
 

--- a/tests/integration/share-and-view.test.ts
+++ b/tests/integration/share-and-view.test.ts
@@ -120,6 +120,14 @@ function waitForFileContent(
   });
 }
 
+const OPEN_BROWSER = process.env.LIVEDOWN_OPEN_BROWSER === "1";
+
+async function openInBrowser(url: string): Promise<void> {
+  if (!OPEN_BROWSER) return;
+  const open = (await import("open")).default;
+  await open(url);
+}
+
 describe("integration: share and view", () => {
   let cli: CliInfo;
   let viewer: WebSocket;
@@ -141,12 +149,14 @@ describe("integration: share and view", () => {
 
   it("share: CLI connects to relay and prints join info", async () => {
     cli = await startCli();
+    await openInBrowser(cli.viewerUrl);
     expect(cli.editKey).toMatch(/^[a-f0-9]{64}$/);
     expect(cli.roomUrl).toContain("livedown.dwmkerr.partykit.dev");
   });
 
   it("view: viewer connects and receives init with sharer present", async () => {
     cli = await startCli();
+    await openInBrowser(cli.viewerUrl);
     viewer = await connectViewer(cli.roomUrl);
     const init = await waitForMessage(viewer, "init");
     expect(init.hasSharer).toBe(true);
@@ -156,6 +166,7 @@ describe("integration: share and view", () => {
 
   it("edit rejected: unsigned push returns auth-error", async () => {
     cli = await startCli();
+    await openInBrowser(cli.viewerUrl);
     viewer = await connectViewer(cli.roomUrl);
     await waitForMessage(viewer, "init");
 
@@ -173,6 +184,7 @@ describe("integration: share and view", () => {
 
   it("edit online: signed push updates the local file", async () => {
     cli = await startCli();
+    await openInBrowser(cli.viewerUrl);
     viewer = await connectViewer(cli.roomUrl);
     await waitForMessage(viewer, "init");
 
@@ -193,6 +205,7 @@ describe("integration: share and view", () => {
 
   it("edit local: file change on disk is pushed to viewer", async () => {
     cli = await startCli();
+    await openInBrowser(cli.viewerUrl);
     viewer = await connectViewer(cli.roomUrl);
     await waitForMessage(viewer, "init");
 
@@ -206,6 +219,7 @@ describe("integration: share and view", () => {
 
   it("close: killing the CLI sends sharer-gone", async () => {
     cli = await startCli();
+    await openInBrowser(cli.viewerUrl);
     viewer = await connectViewer(cli.roomUrl);
     await waitForMessage(viewer, "init");
 

--- a/tests/integration/share-and-view.test.ts
+++ b/tests/integration/share-and-view.test.ts
@@ -1,0 +1,187 @@
+import { ChildProcess, spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import WebSocket from "ws";
+import { signContent } from "../../src/token";
+
+const TEST_FILE = path.resolve(__dirname, "../documents/empty.md");
+const CLI_PATH = path.resolve(__dirname, "../../dist/cli.js");
+const STARTUP_TIMEOUT = 15000;
+const MSG_TIMEOUT = 5000;
+
+interface CliInfo {
+  proc: ChildProcess;
+  roomUrl: string;
+  viewerUrl: string;
+  editKey: string;
+}
+
+function startCli(): Promise<CliInfo> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", [CLI_PATH, "share", TEST_FILE], {
+      env: { ...process.env, FORCE_COLOR: "0" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error(`CLI did not start in ${STARTUP_TIMEOUT}ms: ${stdout}`));
+    }, STARTUP_TIMEOUT);
+
+    proc.stdout!.on("data", (data: Buffer) => {
+      stdout += data.toString();
+      // Strip ANSI escape codes for parsing
+      const clean = stdout.replace(
+        /\x1b\[[0-9;]*[a-zA-Z]|\x1b\]8;;[^\x07]*\x07/g,
+        ""
+      );
+      const urlMatch = clean.match(
+        /https:\/\/livedown\.dwmkerr\.partykit\.dev\/#([a-z0-9]+\/[^\s]+)/
+      );
+      const keyMatch = clean.match(/Edit key\s+([a-f0-9]{64})/);
+      if (urlMatch && keyMatch) {
+        clearTimeout(timeout);
+        const doc = urlMatch[1];
+        resolve({
+          proc,
+          viewerUrl: `https://livedown.dwmkerr.partykit.dev/#${doc}`,
+          roomUrl: `wss://livedown.dwmkerr.partykit.dev/parties/main/${encodeURIComponent(doc)}`,
+          editKey: keyMatch[1],
+        });
+      }
+    });
+
+    proc.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`CLI exited early with code ${code}: ${stdout}`));
+    });
+  });
+}
+
+function connectViewer(roomUrl: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(roomUrl);
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error("Viewer WebSocket did not open"));
+    }, MSG_TIMEOUT);
+    ws.on("open", () => {
+      clearTimeout(timeout);
+      resolve(ws);
+    });
+    ws.on("error", (e) => {
+      clearTimeout(timeout);
+      reject(e);
+    });
+  });
+}
+
+function waitForMessage(
+  ws: WebSocket,
+  type: string,
+  timeoutMs = MSG_TIMEOUT
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for '${type}' message`));
+    }, timeoutMs);
+    const handler = (data: WebSocket.Data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === type) {
+        clearTimeout(timeout);
+        ws.removeListener("message", handler);
+        resolve(msg);
+      }
+    };
+    ws.on("message", handler);
+  });
+}
+
+describe("integration: share and view", () => {
+  let cli: CliInfo;
+  let viewer: WebSocket;
+  let originalContent: string;
+
+  beforeAll(async () => {
+    originalContent = fs.readFileSync(TEST_FILE, "utf8");
+    // Build first to make sure dist/cli.js exists
+    expect(fs.existsSync(CLI_PATH)).toBe(true);
+  });
+
+  afterAll(() => {
+    fs.writeFileSync(TEST_FILE, originalContent, "utf8");
+  });
+
+  afterEach(() => {
+    if (viewer && viewer.readyState === WebSocket.OPEN) viewer.close();
+    if (cli?.proc && !cli.proc.killed) cli.proc.kill();
+  });
+
+  it("full share/view/edit/offline lifecycle", async () => {
+    // 1. Start the CLI sharing the test file
+    cli = await startCli();
+    expect(cli.editKey).toMatch(/^[a-f0-9]{64}$/);
+    expect(cli.roomUrl).toContain("livedown.dwmkerr.partykit.dev");
+
+    // 2. Connect as a viewer
+    viewer = await connectViewer(cli.roomUrl);
+
+    // 3. Verify init message
+    const init = await waitForMessage(viewer, "init");
+    expect(init.hasSharer).toBe(true);
+    expect(init.protected).toBe(true);
+    expect(init.publicKey).toBeTruthy();
+
+    // 4. Push without signature - expect auth-error
+    viewer.send(
+      JSON.stringify({
+        type: "push",
+        content: "unsigned attempt",
+        meta: { editor: "attacker" },
+      })
+    );
+    const authError = await waitForMessage(viewer, "auth-error");
+    expect(authError.type).toBe("auth-error");
+
+    // 5. Push with valid signature - expect update broadcast
+    const testContent = "# Integration Test\n\nWritten by the test suite.";
+    const signature = signContent(testContent, cli.editKey);
+    viewer.send(
+      JSON.stringify({
+        type: "push",
+        content: testContent,
+        signature,
+        meta: { editor: "test-viewer" },
+      })
+    );
+
+    // The relay broadcasts the update to other connections (excluding sender).
+    // Since we're the only viewer, we won't receive the update broadcast.
+    // But the watcher (the CLI) WILL receive it and write to disk.
+    // Wait for the file to be updated.
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("File not updated within timeout")),
+        MSG_TIMEOUT
+      );
+      const check = () => {
+        const content = fs.readFileSync(TEST_FILE, "utf8");
+        if (content.includes("Integration Test")) {
+          clearTimeout(timeout);
+          resolve();
+        } else {
+          setTimeout(check, 200);
+        }
+      };
+      check();
+    });
+    const fileContent = fs.readFileSync(TEST_FILE, "utf8");
+    expect(fileContent).toContain("Integration Test");
+
+    // 6. Kill the CLI - expect sharer-gone
+    cli.proc.kill();
+    const gone = await waitForMessage(viewer, "sharer-gone", 10000);
+    expect(gone.type).toBe("sharer-gone");
+  }, 30000);
+});

--- a/tests/integration/share-and-view.test.ts
+++ b/tests/integration/share-and-view.test.ts
@@ -31,7 +31,6 @@ function startCli(): Promise<CliInfo> {
 
     proc.stdout!.on("data", (data: Buffer) => {
       stdout += data.toString();
-      // Strip ANSI escape codes for parsing
       const clean = stdout.replace(
         /\x1b\[[0-9;]*[a-zA-Z]|\x1b\]8;;[^\x07]*\x07/g,
         ""
@@ -98,6 +97,29 @@ function waitForMessage(
   });
 }
 
+function waitForFileContent(
+  filePath: string,
+  match: string,
+  timeoutMs = MSG_TIMEOUT
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`File did not contain "${match}" within timeout`)),
+      timeoutMs
+    );
+    const check = () => {
+      const content = fs.readFileSync(filePath, "utf8");
+      if (content.includes(match)) {
+        clearTimeout(timeout);
+        resolve(content);
+      } else {
+        setTimeout(check, 200);
+      }
+    };
+    check();
+  });
+}
+
 describe("integration: share and view", () => {
   let cli: CliInfo;
   let viewer: WebSocket;
@@ -105,7 +127,6 @@ describe("integration: share and view", () => {
 
   beforeAll(async () => {
     originalContent = fs.readFileSync(TEST_FILE, "utf8");
-    // Build first to make sure dist/cli.js exists
     expect(fs.existsSync(CLI_PATH)).toBe(true);
   });
 
@@ -118,22 +139,26 @@ describe("integration: share and view", () => {
     if (cli?.proc && !cli.proc.killed) cli.proc.kill();
   });
 
-  it("full share/view/edit/offline lifecycle", async () => {
-    // 1. Start the CLI sharing the test file
+  it("share: CLI connects to relay and prints join info", async () => {
     cli = await startCli();
     expect(cli.editKey).toMatch(/^[a-f0-9]{64}$/);
     expect(cli.roomUrl).toContain("livedown.dwmkerr.partykit.dev");
+  });
 
-    // 2. Connect as a viewer
+  it("view: viewer connects and receives init with sharer present", async () => {
+    cli = await startCli();
     viewer = await connectViewer(cli.roomUrl);
-
-    // 3. Verify init message
     const init = await waitForMessage(viewer, "init");
     expect(init.hasSharer).toBe(true);
     expect(init.protected).toBe(true);
     expect(init.publicKey).toBeTruthy();
+  });
 
-    // 4. Push without signature - expect auth-error
+  it("edit rejected: unsigned push returns auth-error", async () => {
+    cli = await startCli();
+    viewer = await connectViewer(cli.roomUrl);
+    await waitForMessage(viewer, "init");
+
     viewer.send(
       JSON.stringify({
         type: "push",
@@ -141,47 +166,51 @@ describe("integration: share and view", () => {
         meta: { editor: "attacker" },
       })
     );
-    const authError = await waitForMessage(viewer, "auth-error");
-    expect(authError.type).toBe("auth-error");
 
-    // 5. Push with valid signature - expect update broadcast
-    const testContent = "# Integration Test\n\nWritten by the test suite.";
-    const signature = signContent(testContent, cli.editKey);
+    const err = await waitForMessage(viewer, "auth-error");
+    expect(err.type).toBe("auth-error");
+  });
+
+  it("edit online: signed push updates the local file", async () => {
+    cli = await startCli();
+    viewer = await connectViewer(cli.roomUrl);
+    await waitForMessage(viewer, "init");
+
+    const content = "# Edit Online Test\n\nPushed from the viewer.";
+    const signature = signContent(content, cli.editKey);
     viewer.send(
       JSON.stringify({
         type: "push",
-        content: testContent,
+        content,
         signature,
         meta: { editor: "test-viewer" },
       })
     );
 
-    // The relay broadcasts the update to other connections (excluding sender).
-    // Since we're the only viewer, we won't receive the update broadcast.
-    // But the watcher (the CLI) WILL receive it and write to disk.
-    // Wait for the file to be updated.
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error("File not updated within timeout")),
-        MSG_TIMEOUT
-      );
-      const check = () => {
-        const content = fs.readFileSync(TEST_FILE, "utf8");
-        if (content.includes("Integration Test")) {
-          clearTimeout(timeout);
-          resolve();
-        } else {
-          setTimeout(check, 200);
-        }
-      };
-      check();
-    });
-    const fileContent = fs.readFileSync(TEST_FILE, "utf8");
-    expect(fileContent).toContain("Integration Test");
+    const fileContent = await waitForFileContent(TEST_FILE, "Edit Online Test");
+    expect(fileContent).toContain("Pushed from the viewer.");
+  });
 
-    // 6. Kill the CLI - expect sharer-gone
+  it("edit local: file change on disk is pushed to viewer", async () => {
+    cli = await startCli();
+    viewer = await connectViewer(cli.roomUrl);
+    await waitForMessage(viewer, "init");
+
+    // Write directly to the file the CLI is watching
+    fs.writeFileSync(TEST_FILE, "# Local Edit\n\nWritten on disk.", "utf8");
+
+    const update = await waitForMessage(viewer, "update", 10000);
+    expect(update.content).toContain("Local Edit");
+    expect(update.signature).toBeTruthy();
+  });
+
+  it("close: killing the CLI sends sharer-gone", async () => {
+    cli = await startCli();
+    viewer = await connectViewer(cli.roomUrl);
+    await waitForMessage(viewer, "init");
+
     cli.proc.kill();
     const gone = await waitForMessage(viewer, "sharer-gone", 10000);
     expect(gone.type).toBe("sharer-gone");
-  }, 30000);
+  });
 });


### PR DESCRIPTION
## Summary
- Remove blocking clipboard confirm prompt; show "(press c to copy)" inline after the edit key
- Change hotkey from `t` to `c` and label from "copy edit key" to "copy key"
- Fix duplicate hints line at the bottom (watcher's `log()` already wrote HINTS after "Connected to room")
- Replace inquirer input with Node's `readline` + filesystem completer so interactive file prompt supports tab completion
- `npm run build` now sets executable bit on `dist/cli.js`

## Screenshots

### Before
Clipboard confirm prompt flashed briefly then jumped straight to "Connected to room"; hint line shown twice: `c copy key  q quit  c copy key  q quit`.

### After
Edit key line includes "(press c to copy)"; single hint line; tab completion works in interactive file prompt.