### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ scratch/
 coverage/
 .worktrees/
 scheduled_tasks.lock
+.claude/worktrees/


### PR DESCRIPTION
Small hygiene: the Claude subagent worktree path isn't ignored, so `git add -A` scoops it up. Flip repo public is waiting on this.