### PR TITLE
fix(ci): split cicd + deploy, add partykit preflight and timeout

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,3 +1,14 @@
+# CI/CD — internal to the repo.
+#
+# Validates PRs and pushes to main. On main, runs release-please to cut a
+# release (tag + GitHub Release + CHANGELOG + version bump in package.json).
+# When release-please creates a release, dispatches the external `deploy`
+# workflow, which is what actually pushes artefacts to npm and PartyKit.
+#
+# Responsibility split:
+#   cicd.yaml   — internal: validate, cut release (repo-state changes)
+#   deploy.yaml — external: publish to npm + deploy relay to PartyKit
+
 name: cicd
 
 on:
@@ -48,30 +59,10 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  publish-npm:
-    needs: [release]
-    if: needs.release.outputs.releases_created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_LTS_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-      - run: npm ci
-      - run: npm run build
-      - run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  # Fire the deploy workflow once the release has been published to npm.
-  # Keeping deploy in a separate workflow lets us re-run just the partykit
-  # deploy manually without re-running the full release pipeline.
+  # When release-please cuts a release, kick off the external deploy.
+  # Deploy publishes to npm and pushes the relay to PartyKit in parallel.
   dispatch-deploy:
-    needs: [release, publish-npm]
+    needs: [release]
     if: needs.release.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -40,6 +40,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     outputs:
       releases_created: ${{ steps.release-please.outputs.releases_created }}
+      tag_name: ${{ steps.release-please.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release-please
@@ -65,3 +66,18 @@ jobs:
       - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Fire the deploy workflow once the release has been published to npm.
+  # Keeping deploy in a separate workflow lets us re-run just the partykit
+  # deploy manually without re-running the full release pipeline.
+  dispatch-deploy:
+    needs: [release, publish-npm]
+    if: needs.release.outputs.releases_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dispatch deploy workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.tag_name }}
+        run: gh workflow run deploy.yaml --ref "$TAG"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,3 +1,24 @@
+# Deploy — external.
+#
+# Publishes the release artefacts to the outside world:
+#   - npm:      @dwmkerr/livedown
+#   - PartyKit: livedown.dwmkerr.partykit.dev
+#
+# Both jobs run in parallel. A failure in one does not roll back the other
+# (npm publish is effectively immutable), but keeping them independent means
+# a broken relay deploy can be retried in isolation with `workflow_dispatch`
+# without re-publishing npm.
+#
+# Trigger paths:
+#   - Automatic: dispatched from cicd.yaml after release-please cuts a tag.
+#   - Manual:    `gh workflow run deploy.yaml --ref <tag>` or Actions UI.
+#
+# Secrets:
+#   NPM_TOKEN        — npm "Automation" token with write on the `@dwmkerr` scope.
+#   PARTYKIT_TOKEN   — `npx partykit token generate` on a machine logged in
+#                      as the relay owner (username must match PARTYKIT_LOGIN
+#                      below).
+
 name: deploy
 
 on:
@@ -15,6 +36,36 @@ env:
   PARTYKIT_LOGIN: dwmkerr
 
 jobs:
+  deploy-npm:
+    runs-on: ubuntu-latest
+    # Caps protect against npm CLI hangs or transparency-log delays.
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_LTS_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
+      # Preflight: confirm the NPM token is valid before attempting publish,
+      # so a stale/wrong token surfaces as an obvious auth failure rather than
+      # a confusing 404 on PUT.
+      - name: Preflight — npm auth
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance
+
   deploy-partykit:
     runs-on: ubuntu-latest
     # Cap at 5 minutes so a misconfigured token can't silently burn Actions

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,28 +2,45 @@ name: deploy
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [cicd]
-    types: [completed]
-    branches: [main]
+    inputs:
+      ref:
+        description: "Git ref (tag, branch, or SHA) to deploy. Defaults to the current ref the workflow was dispatched on."
+        required: false
+        type: string
 
 env:
   NODE_LTS_VERSION: 24.x
+  # PARTYKIT_LOGIN is a username, not a secret — hardcoded here so partykit
+  # CLI commands work consistently regardless of who/what triggers the deploy.
+  PARTYKIT_LOGIN: dwmkerr
 
 jobs:
   deploy-partykit:
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push')
+    # Cap at 5 minutes so a misconfigured token can't silently burn Actions
+    # minutes waiting on an interactive prompt.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           cache: "npm"
       - run: npm ci
-      - run: npx partykit deploy
+      # Preflight: fail fast with a clear error if PARTYKIT_TOKEN is missing
+      # or invalid rather than hanging inside `partykit deploy`.
+      - name: Preflight — partykit auth
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+        run: |
+          if [ -z "$PARTYKIT_TOKEN" ]; then
+            echo "::error::PARTYKIT_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+          npx partykit whoami
+      - name: Deploy partykit
+        env:
+          PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+        run: npx partykit deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,10 +75,10 @@ Run the security agent (`.claude/agents/security.md`) before merging security-se
 
 ## Deployment
 
-Two workflows, one responsibility each:
+Two workflows, one responsibility each. **Internal vs external** is the split:
 
-- `.github/workflows/cicd.yaml` — validates PRs + pushes to `main`, runs `release-please`, publishes to npm on release, then dispatches `deploy.yaml` with the new tag as `ref`.
-- `.github/workflows/deploy.yaml` — `workflow_dispatch` only. Checks out the requested `ref`, runs `npx partykit whoami` as a preflight, then `npx partykit deploy`. Job has `timeout-minutes: 5` so a bad token never burns Actions minutes.
+- `.github/workflows/cicd.yaml` — **internal to the repo**. Validates PRs + pushes to `main`, then runs `release-please` to cut a release (tag + GitHub Release + CHANGELOG + version bump). When a release is cut, dispatches `deploy.yaml` with the new tag as `ref`. Nothing leaves the repo from this workflow.
+- `.github/workflows/deploy.yaml` — **external**. Publishes to npm (`deploy-npm` job) and deploys the relay to PartyKit (`deploy-partykit` job) in parallel. Both jobs preflight their auth (`npm whoami`, `npx partykit whoami`) and carry `timeout-minutes` caps so a misconfigured token surfaces as a fast auth failure rather than a hang.
 
 ### Manual deploy
 
@@ -93,8 +93,8 @@ Or: Actions tab → `deploy` → "Run workflow".
 
 All set under repo Settings → Secrets and variables → Actions:
 
-- `NPM_TOKEN` — npm "Automation" classic token with write access on the `@dwmkerr` scope. Rotate at npmjs.com → Access Tokens. Used by `publish-npm`.
-- `PARTYKIT_TOKEN` — generated at partykit.io dashboard → settings. Used by `deploy.yaml` to push the relay. Rotate there and paste the new value into Actions secrets.
+- `NPM_TOKEN` — npm "Automation" / granular token with `package: write` on the `@dwmkerr` scope. Generate at npmjs.com → Access Tokens. Used by `deploy-npm` job in `deploy.yaml`.
+- `PARTYKIT_TOKEN` — generate with `npx partykit token generate` on a machine logged in as the relay owner (`dwmkerr`). Used by `deploy-partykit` job in `deploy.yaml`. Rotate by regenerating and pasting the new value into Actions secrets.
 - `CODECOV_TOKEN` — upload coverage from `validate` job.
 - `ANTHROPIC_API_KEY` — used by Claude-driven workflows (agent-actions, openspec-flow, security-review).
 - `AGENT_GITHUB_TOKEN` — PAT used by agent workflows that need repo write scope beyond the default `GITHUB_TOKEN`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,34 @@ Run the security agent (`.claude/agents/security.md`) before merging security-se
 - CLI changes should include terminal screenshots for non-trivial changes
 - Never add breadcrumb comments — only explain *why*, not *what*
 
+## Deployment
+
+Two workflows, one responsibility each:
+
+- `.github/workflows/cicd.yaml` — validates PRs + pushes to `main`, runs `release-please`, publishes to npm on release, then dispatches `deploy.yaml` with the new tag as `ref`.
+- `.github/workflows/deploy.yaml` — `workflow_dispatch` only. Checks out the requested `ref`, runs `npx partykit whoami` as a preflight, then `npx partykit deploy`. Job has `timeout-minutes: 5` so a bad token never burns Actions minutes.
+
+### Manual deploy
+
+```bash
+gh workflow run deploy.yaml --ref main                 # deploy tip of main
+gh workflow run deploy.yaml --ref v1.2.3 -f ref=v1.2.3 # deploy a specific release
+```
+
+Or: Actions tab → `deploy` → "Run workflow".
+
+### Secrets
+
+All set under repo Settings → Secrets and variables → Actions:
+
+- `NPM_TOKEN` — npm "Automation" classic token with write access on the `@dwmkerr` scope. Rotate at npmjs.com → Access Tokens. Used by `publish-npm`.
+- `PARTYKIT_TOKEN` — generated at partykit.io dashboard → settings. Used by `deploy.yaml` to push the relay. Rotate there and paste the new value into Actions secrets.
+- `CODECOV_TOKEN` — upload coverage from `validate` job.
+- `ANTHROPIC_API_KEY` — used by Claude-driven workflows (agent-actions, openspec-flow, security-review).
+- `AGENT_GITHUB_TOKEN` — PAT used by agent workflows that need repo write scope beyond the default `GITHUB_TOKEN`.
+
+`PARTYKIT_LOGIN` is the partykit username (currently `dwmkerr`). It is **not** a secret — it's hardcoded at the workflow `env:` level in `deploy.yaml`. Change it there if the relay account changes.
+
 ## Key Files
 
 - `src/token.ts` — Ed25519 keypair generation, signing, verification (tweetnacl)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
   <p align="center">
     <a href="https://github.com/dwmkerr/livedown/actions/workflows/cicd.yaml"><img src="https://github.com/dwmkerr/livedown/actions/workflows/cicd.yaml/badge.svg" alt="cicd"></a>
+    <a href="https://github.com/dwmkerr/livedown/actions/workflows/deploy.yaml"><img src="https://github.com/dwmkerr/livedown/actions/workflows/deploy.yaml/badge.svg" alt="deploy"></a>
     <a href="https://www.npmjs.com/package/@dwmkerr/livedown"><img src="https://img.shields.io/npm/v/%40dwmkerr/livedown" alt="npm version"></a>
     <a href="https://codecov.io/gh/dwmkerr/livedown"><img src="https://codecov.io/gh/dwmkerr/livedown/graph/badge.svg" alt="codecov"></a>
   </p>


### PR DESCRIPTION
## Summary

Split CI/CD and deploy into two atomic workflows matching the pattern used elsewhere (reference: [`dwmkerr/mock-llm` cicd.yaml](https://github.com/dwmkerr/mock-llm/blob/main/.github/workflows/cicd.yaml) — release-please outputs gate downstream jobs).

### What changed

- **`.github/workflows/cicd.yaml`**
  - `release` job now also exposes `tag_name` alongside `releases_created`.
  - New `dispatch-deploy` job (`needs: [release, publish-npm]`) fires `deploy.yaml` with the released tag as `ref` via `gh workflow run`.
- **`.github/workflows/deploy.yaml`**
  - Removed the `workflow_run` trigger. It was running on every push to main and hanging because `PARTYKIT_LOGIN` was never set and there was no timeout.
  - `workflow_dispatch` only, with optional `ref` input (defaults to the dispatch ref).
  - `timeout-minutes: 5` on the job so bad auth fails fast.
  - Preflight step runs `npx partykit whoami` — errors out with a clear message if `PARTYKIT_TOKEN` is missing.
  - `PARTYKIT_LOGIN: dwmkerr` hardcoded at workflow env level (username, not a secret).
- **`README.md`** — deploy badge added alongside cicd, npm, codecov.
- **`CLAUDE.md`** — new Deployment section covering the two-workflow architecture, manual dispatch, and secret rotation (`NPM_TOKEN`, `PARTYKIT_TOKEN`, `CODECOV_TOKEN`, `ANTHROPIC_API_KEY`, `AGENT_GITHUB_TOKEN`).

### Why

- The previous `deploy.yaml` triggered on every merge to main and hung indefinitely (no timeout, missing `PARTYKIT_LOGIN`), burning Actions minutes.
- Coupling deploy to CI/CD meant a failed deploy blocked routine pushes; decoupling lets manual redeploys happen without a release.
- Firing deploy from cicd only after `publish-npm` succeeds keeps npm and partykit releases in lockstep without bundling them in one brittle job.

### Verification plan

- [ ] Once `PARTYKIT_TOKEN` is set, manually dispatch `deploy.yaml` (`gh workflow run deploy.yaml --ref main`) and confirm it completes under 5 minutes.
- [ ] Confirm preflight fails fast (with a clear error) if the token is unset or invalid.
- [ ] On the next release-please merge, watch the full chain: `validate` → `release` → `publish-npm` → `dispatch-deploy` → `deploy.yaml` run appears in the Actions tab tagged at the new release.
- [ ] Confirm both cicd and deploy badges render in README.