### PR TITLE
fix(cicd): grant actions:write to dispatch-deploy job

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -61,10 +61,17 @@ jobs:
 
   # When release-please cuts a release, kick off the external deploy.
   # Deploy publishes to npm and pushes the relay to PartyKit in parallel.
+  #
+  # `actions: write` is required so the default GITHUB_TOKEN can call
+  # `gh workflow run`; without it GitHub returns 403 "Resource not
+  # accessible by integration" on the dispatch endpoint.
   dispatch-deploy:
     needs: [release]
     if: needs.release.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Dispatch deploy workflow


### PR DESCRIPTION
Release 0.1.4 cut but dispatch-deploy failed with HTTP 403 'Resource not accessible by integration'. Default `GITHUB_TOKEN` needs `actions: write` to call `gh workflow run`. After merge, manual dispatch to complete v0.1.4 deploy.