### PR TITLE
chore: remove redundant `livedown open` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,6 @@ Options:
 - `-e, --editor <name>` — Your name shown to viewers
 - `-k, --edit-key <key>` — Edit key (auto-generated if omitted)
 
-### `livedown open <url>`
-
-Open a shared document in the browser.
-
-```bash
-livedown open https://livedown.dwmkerr.partykit.dev/#abc123/notes.md
-```
-
 ## Docker
 
 Run Livedown without installing Node.js by using the published Docker image.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -10,7 +10,6 @@ describe("cli", () => {
     });
     expect(output).toContain("livedown");
     expect(output).toContain("share");
-    expect(output).toContain("open");
   });
 
   it("should show version", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,15 +146,6 @@ program
   .option("-k, --edit-key <key>", "Edit key (auto-generated if omitted)")
   .action(startSharing);
 
-program
-  .command("open")
-  .description("Open a shared document in the browser")
-  .argument("<url>", "Livedown viewer URL")
-  .action(async (url: string) => {
-    const open = (await import("open")).default;
-    await open(url);
-  });
-
 function fileCompleter(line: string): [string[], string] {
   // Determine the directory to list and the prefix to filter by.
   // - Empty input → list current directory


### PR DESCRIPTION
Pure alias over OS `open`/`xdg-open`, no livedown logic. `--edit-key` kept (real session-resume feature, not a duplicate of auto-generation).