### PR TITLE
fix(openspec-flow): allow agent to edit .github/workflows via repo var

### DIFF
--- a/.github/workflows/openspec-flow.yaml
+++ b/.github/workflows/openspec-flow.yaml
@@ -95,6 +95,16 @@ env:
   # comments. Do not change casually — stale markers will leak.
   AGENT_COMMENT_MARKER: "<!-- openspec-flow-summary -->"
   REENGAGE_FOOTER: "Add the `openspec:start` label to re-engage the agent with the latest discussion."
+  # Extra scopes requested on the OIDC-exchanged installation token used by
+  # the agent step. Sourced from the repo/org variable
+  # `AGENT_ADDITIONAL_PERMISSIONS` so each project decides in its own
+  # Settings → Actions → Variables (not in source). Unset / empty =
+  # defaults (contents/pull_requests/issues: write). Set to
+  # `workflows: write` if implement tasks need to edit
+  # `.github/workflows/*.yaml` — also requires granting the Claude
+  # GitHub App `workflows: read and write` on the repo. See CLAUDE.md →
+  # "Agent workflow permissions".
+  AGENT_ADDITIONAL_PERMISSIONS: ${{ vars.AGENT_ADDITIONAL_PERMISSIONS }}
 
 permissions:
   contents: write
@@ -406,7 +416,8 @@ jobs:
             --arg api_key "$ANTHROPIC_API_KEY" \
             --arg gh_token "$GITHUB_TOKEN" \
             --arg claude_args "$CLAUDE_ARGS" \
-            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args}')"
+            --arg extra_perms "$AGENT_ADDITIONAL_PERMISSIONS" \
+            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
           export ALL_INPUTS
           bun run /tmp/claude-code-action/src/entrypoints/run.ts
 
@@ -718,7 +729,8 @@ jobs:
             --arg api_key "$ANTHROPIC_API_KEY" \
             --arg gh_token "$GITHUB_TOKEN" \
             --arg claude_args "$CLAUDE_ARGS" \
-            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args}')"
+            --arg extra_perms "$AGENT_ADDITIONAL_PERMISSIONS" \
+            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
           export ALL_INPUTS
           bun run /tmp/claude-code-action/src/entrypoints/run.ts
 
@@ -956,7 +968,8 @@ jobs:
             --arg api_key "$ANTHROPIC_API_KEY" \
             --arg gh_token "$GITHUB_TOKEN" \
             --arg claude_args "$CLAUDE_ARGS" \
-            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args}')"
+            --arg extra_perms "$AGENT_ADDITIONAL_PERMISSIONS" \
+            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
           export ALL_INPUTS
           bun run /tmp/claude-code-action/src/entrypoints/run.ts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,37 @@ All set under repo Settings → Secrets and variables → Actions:
 
 `PARTYKIT_LOGIN` is the partykit username (currently `dwmkerr`). It is **not** a secret — it's hardcoded at the workflow `env:` level in `deploy.yaml`. Change it there if the relay account changes.
 
+## Agent workflow permissions
+
+The OpenSpec Flow agent step (in `.github/workflows/openspec-flow.yaml`) runs `anthropics/claude-code-action`, which exchanges the OIDC token for a GitHub App installation token. That token grants **only** `contents: write`, `pull_requests: write`, `issues: write` by default — **not** `workflows: write`. Any agent attempt to push `.github/workflows/*.yaml` changes will be silently dropped from the commit or rejected at push.
+
+This is observable as impl PRs that archive + update main specs but contain zero workflow edits, even when the spec target is the flow workflow itself.
+
+To grant the agent `workflows: write`, two things are required (both must be set):
+
+**1. Repo / org variable `AGENT_ADDITIONAL_PERMISSIONS`**
+
+- Non-secret, lives in Settings → Secrets and variables → Actions → **Variables** tab → New repository variable.
+- Name: `AGENT_ADDITIONAL_PERMISSIONS`
+- Value: `workflows: write`
+- Unset / empty = action default (no extra scope).
+- Forwarded to `claude-code-action` as the `additional_permissions` input via the workflow's top-level `env:` block.
+
+```bash
+gh variable set AGENT_ADDITIONAL_PERMISSIONS --body "workflows: write"  # enable
+gh variable delete AGENT_ADDITIONAL_PERMISSIONS                        # disable
+```
+
+**2. Claude GitHub App permission on the repo**
+
+- Settings → **GitHub Apps** → Claude → Configure (the repo-level link)
+- Repository permissions → **Workflows** → Read and write
+- Save.
+
+Without step 2, step 1 has no effect — the OIDC exchange can only grant scopes the app is installed with.
+
+**Default state for new projects**: leave `AGENT_ADDITIONAL_PERMISSIONS` unset. Only turn on when implement tasks legitimately need to edit `.github/workflows/*.yaml`. livedown has it on because its own flow workflow is a primary implementation target (meta: the flow can modify itself).
+
 ## Key Files
 
 - `src/token.ts` — Ed25519 keypair generation, signing, verification (tweetnacl)


### PR DESCRIPTION
## Summary
- Installation token lacked `workflows: write`; impl agents silently dropped workflow-file changes (cause of #52's three archive-only PRs and #46/#48 no-PR silent failures, all targeting the flow workflow)
- Workflow now forwards `vars.AGENT_ADDITIONAL_PERMISSIONS` to claude-code-action as `additional_permissions`. Default empty. Set to `workflows: write` per repo to enable
- Livedown's repo variable set to `workflows: write` (done via `gh variable set`). Also requires Claude GitHub App → Configure → Workflows: Read and write on this repo
- CLAUDE.md: new "Agent workflow permissions" section explaining both steps + how to toggle + note that default-off is safer for forks

## Post-merge
1. Grant Claude GitHub App `workflows: read and write` on dwmkerr/livedown (Settings → GitHub Apps → Claude → Configure)
2. Retrigger implement on #52 (and #46, #48 if you want those reattempted) — now should produce real code, not archive-only