### PR TITLE
debug(implement): temporarily show_full_output=true for #52 diagnosis

### DIFF
--- a/.github/workflows/openspec-flow.yaml
+++ b/.github/workflows/openspec-flow.yaml
@@ -724,13 +724,17 @@ jobs:
             - Conventional commit PR title.
         run: |
           export CLAUDE_ARGS="--permission-mode bypassPermissions"
+          # DEBUG: show_full_output=true temporarily so the agent's tool
+          # calls + reasoning are visible in the run log. Revert after
+          # diagnosing #52 impl silent-no-op. App token is registered via
+          # core.setSecret() so it is still redacted in the visible log.
           ALL_INPUTS="$(jq -nc \
             --arg prompt "$PROMPT" \
             --arg api_key "$ANTHROPIC_API_KEY" \
             --arg gh_token "$GITHUB_TOKEN" \
             --arg claude_args "$CLAUDE_ARGS" \
             --arg extra_perms "$AGENT_ADDITIONAL_PERMISSIONS" \
-            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
+            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms, show_full_output: "true"}')"
           export ALL_INPUTS
           bun run /tmp/claude-code-action/src/entrypoints/run.ts
 


### PR DESCRIPTION
TEMPORARY. Revert after diagnosis — per action's own recommendation when full output needed. App token is core.setSecret()-redacted.