### PR TITLE
refactor: extract agent run into composite action (3× dedupe)

### DIFF
--- a/.github/actions/openspec-flow-run-agent/action.yml
+++ b/.github/actions/openspec-flow-run-agent/action.yml
@@ -1,0 +1,78 @@
+name: openspec-flow-run-agent
+description: |
+  Thin wrapper around `anthropics/claude-code-action`'s entrypoint,
+  factored out of the plan/implement/respond jobs to stop triplicating
+  the ALL_INPUTS jq construction and env wiring.
+
+  The caller is responsible for:
+    - `actions/checkout` of the target repo
+    - cloning claude-code-action to `claude_code_action_path`
+    - installing bun on PATH
+
+inputs:
+  prompt:
+    description: Full agent prompt text.
+    required: true
+  anthropic_api_key:
+    description: Anthropic API key (from secrets.ANTHROPIC_API_KEY).
+    required: true
+  github_token:
+    description: >
+      GitHub token the agent uses for API calls and git push. Typically
+      ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}.
+    required: true
+  override_github_token:
+    description: >
+      Optional PAT that overrides the OIDC-derived app token. Passed
+      through as OVERRIDE_GITHUB_TOKEN env var.
+    required: false
+    default: ""
+  additional_permissions:
+    description: >
+      Extra scopes to request on the OIDC-exchanged installation token.
+      Must match the env var name the action reads
+      (process.env.ADDITIONAL_PERMISSIONS in src/github/token.ts).
+      Example: `workflows: write` to let the agent push
+      .github/workflows/*.yaml edits.
+    required: false
+    default: ""
+  show_full_output:
+    description: >
+      If "true", agent tool-call output is visible in the run log.
+      Useful for debugging silent no-ops. Leak risk on public repos —
+      leave off unless investigating.
+    required: false
+    default: "false"
+  claude_code_action_path:
+    description: >
+      Filesystem path where the caller has cloned claude-code-action.
+    required: false
+    default: "/tmp/claude-code-action"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        PROMPT: ${{ inputs.prompt }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        OVERRIDE_GITHUB_TOKEN: ${{ inputs.override_github_token }}
+        ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
+        INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        ACTION_PATH: ${{ inputs.claude_code_action_path }}
+      run: |
+        # Override GITHUB_ACTION_PATH — GH sets it to *this* composite
+        # action's dir by default; claude-code-action's entrypoint needs
+        # its own source tree instead.
+        export GITHUB_ACTION_PATH="$ACTION_PATH"
+        export CLAUDE_ARGS="--permission-mode bypassPermissions"
+        ALL_INPUTS="$(jq -nc \
+          --arg prompt "$PROMPT" \
+          --arg api_key "$ANTHROPIC_API_KEY" \
+          --arg gh_token "$GITHUB_TOKEN" \
+          --arg claude_args "$CLAUDE_ARGS" \
+          --arg extra_perms "$ADDITIONAL_PERMISSIONS" \
+          '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
+        export ALL_INPUTS
+        bun run "$GITHUB_ACTION_PATH/src/entrypoints/run.ts"

--- a/.github/workflows/openspec-flow.yaml
+++ b/.github/workflows/openspec-flow.yaml
@@ -340,12 +340,13 @@ jobs:
 
       - name: Run plan agent
         if: steps.check.outputs.run == 'true'
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
-          OVERRIDE_GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN }}
-          GITHUB_ACTION_PATH: /tmp/claude-code-action
-          PROMPT: |
+        uses: ./.github/actions/openspec-flow-run-agent
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          override_github_token: ${{ secrets.AGENT_GITHUB_TOKEN }}
+          additional_permissions: ${{ env.AGENT_ADDITIONAL_PERMISSIONS }}
+          prompt: |
             Drive issue #${{ github.event.issue.number }} in
             ${{ github.repository }} to a draft OpenSpec proposal PR.
             Issue title: "${{ github.event.issue.title }}"
@@ -409,22 +410,6 @@ jobs:
             CONSTRAINTS
             - Write nothing outside `openspec/changes/<name>/`.
             - Conventional commit PR title (`chore:` prefix).
-        run: |
-          export CLAUDE_ARGS="--permission-mode bypassPermissions"
-          # Action reads process.env.ADDITIONAL_PERMISSIONS at
-          # src/github/token.ts:35 when requesting the OIDC-exchanged
-          # installation token. Passing it via ALL_INPUTS JSON is NOT
-          # sufficient — must be an exported env var with this exact name.
-          export ADDITIONAL_PERMISSIONS="$AGENT_ADDITIONAL_PERMISSIONS"
-          ALL_INPUTS="$(jq -nc \
-            --arg prompt "$PROMPT" \
-            --arg api_key "$ANTHROPIC_API_KEY" \
-            --arg gh_token "$GITHUB_TOKEN" \
-            --arg claude_args "$CLAUDE_ARGS" \
-            --arg extra_perms "$AGENT_ADDITIONAL_PERMISSIONS" \
-            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
-          export ALL_INPUTS
-          bun run /tmp/claude-code-action/src/entrypoints/run.ts
 
       # Postflight: plan agent must open a spec PR with at least one file
       # change. Empty diffs can happen when the change folder already
@@ -696,12 +681,13 @@ jobs:
 
       - name: Run implement agent
         if: steps.verify-issue.outputs.run == 'true'
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
-          OVERRIDE_GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN }}
-          GITHUB_ACTION_PATH: /tmp/claude-code-action
-          PROMPT: |
+        uses: ./.github/actions/openspec-flow-run-agent
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          override_github_token: ${{ secrets.AGENT_GITHUB_TOKEN }}
+          additional_permissions: ${{ env.AGENT_ADDITIONAL_PERMISSIONS }}
+          prompt: |
             Drive issue #${{ steps.check.outputs.issue_number }} in
             ${{ github.repository }} through the OpenSpec implement stage.
             The proposal PR for `spec/${{ steps.check.outputs.issue_number }}-${{ steps.check.outputs.change_slug }}`
@@ -727,27 +713,6 @@ jobs:
             CONSTRAINTS
             - Change folder ends under `openspec/changes/archive/<name>/`.
             - Conventional commit PR title.
-        run: |
-          export CLAUDE_ARGS="--permission-mode bypassPermissions"
-          # Action reads process.env.ADDITIONAL_PERMISSIONS at
-          # src/github/token.ts:35 when requesting the OIDC-exchanged
-          # installation token. Passing it via ALL_INPUTS JSON is NOT
-          # sufficient — must be an exported env var with this exact name.
-          export ADDITIONAL_PERMISSIONS="$AGENT_ADDITIONAL_PERMISSIONS"
-          # DEBUG: show_full_output=true via INPUT_SHOW_FULL_OUTPUT env
-          # (action reads process.env.INPUT_SHOW_FULL_OUTPUT at
-          # src/entrypoints/run.ts:274 — ALL_INPUTS JSON is ignored for
-          # this knob). Revert after diagnosing #52 silent no-op.
-          export INPUT_SHOW_FULL_OUTPUT=true
-          ALL_INPUTS="$(jq -nc \
-            --arg prompt "$PROMPT" \
-            --arg api_key "$ANTHROPIC_API_KEY" \
-            --arg gh_token "$GITHUB_TOKEN" \
-            --arg claude_args "$CLAUDE_ARGS" \
-            --arg extra_perms "$AGENT_ADDITIONAL_PERMISSIONS" \
-            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
-          export ALL_INPUTS
-          bun run /tmp/claude-code-action/src/entrypoints/run.ts
 
       # Postflight: agent often reports success but produces no impl PR
       # (silent no-op — #48). Assert the expected artifact exists;
@@ -922,15 +887,13 @@ jobs:
 
       - name: Run respond agent
         if: steps.check.outputs.run == 'true'
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
-          OVERRIDE_GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN }}
-          GITHUB_ACTION_PATH: /tmp/claude-code-action
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BRANCH_KIND: ${{ steps.check.outputs.branch_kind }}
-          CHANGE_SLUG: ${{ steps.check.outputs.change_slug }}
-          PROMPT: |
+        uses: ./.github/actions/openspec-flow-run-agent
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
+          override_github_token: ${{ secrets.AGENT_GITHUB_TOKEN }}
+          additional_permissions: ${{ env.AGENT_ADDITIONAL_PERMISSIONS }}
+          prompt: |
             Refine PR #${{ github.event.pull_request.number }} in
             ${{ github.repository }} based on the conversation so far.
 
@@ -976,22 +939,6 @@ jobs:
               implementation paths for impl PRs. Do not invent new scope.
             - If a reviewer's ask conflicts with the spec, flag the conflict
               in the summary comment rather than silently resolving it.
-        run: |
-          export CLAUDE_ARGS="--permission-mode bypassPermissions"
-          # Action reads process.env.ADDITIONAL_PERMISSIONS at
-          # src/github/token.ts:35 when requesting the OIDC-exchanged
-          # installation token. Passing it via ALL_INPUTS JSON is NOT
-          # sufficient — must be an exported env var with this exact name.
-          export ADDITIONAL_PERMISSIONS="$AGENT_ADDITIONAL_PERMISSIONS"
-          ALL_INPUTS="$(jq -nc \
-            --arg prompt "$PROMPT" \
-            --arg api_key "$ANTHROPIC_API_KEY" \
-            --arg gh_token "$GITHUB_TOKEN" \
-            --arg claude_args "$CLAUDE_ARGS" \
-            --arg extra_perms "$AGENT_ADDITIONAL_PERMISSIONS" \
-            '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
-          export ALL_INPUTS
-          bun run /tmp/claude-code-action/src/entrypoints/run.ts
 
       - name: Remove openspec:start label
         if: always() && steps.check.outputs.run == 'true'


### PR DESCRIPTION
Collapses the three 15-line agent-run blocks into `.github/actions/openspec-flow-run-agent`. Caller specifies prompt + identity inputs; composite handles env wiring, ALL_INPUTS jq, and bun invocation.

Prevents the class of bug we just hit (env-var name drift — AGENT_ADDITIONAL_PERMISSIONS vs ADDITIONAL_PERMISSIONS silently dropped workflow-edit perm across three failed impl runs). Also simplifies debug toggles (show_full_output is now a single input).

Extends #37's composite-actions pattern. Net -56 lines.