### PR TITLE
fix(action): drop secrets expression from composite action description

### DIFF
--- a/.github/actions/openspec-flow-run-agent/action.yml
+++ b/.github/actions/openspec-flow-run-agent/action.yml
@@ -19,7 +19,8 @@ inputs:
   github_token:
     description: >
       GitHub token the agent uses for API calls and git push. Typically
-      ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}.
+      secrets.AGENT_GITHUB_TOKEN with a fallback to github.token — see
+      caller workflow.
     required: true
   override_github_token:
     description: >


### PR DESCRIPTION
Composite actions can't eval `secrets.*`. Run 24780856052 failed with 'Unrecognized named-value: secrets' at action-load. Replace with plain-text description.