### PR TITLE
feat(openspec-flow): support CLAUDE_CODE_OAUTH_TOKEN alongside API key

### DIFF
--- a/.github/actions/openspec-flow-run-agent/action.yml
+++ b/.github/actions/openspec-flow-run-agent/action.yml
@@ -14,8 +14,19 @@ inputs:
     description: Full agent prompt text.
     required: true
   anthropic_api_key:
-    description: Anthropic API key (from secrets.ANTHROPIC_API_KEY).
-    required: true
+    description: >
+      Anthropic API key (from secrets.ANTHROPIC_API_KEY). Optional if
+      `claude_code_oauth_token` is set.
+    required: false
+    default: ""
+  claude_code_oauth_token:
+    description: >
+      Claude Code OAuth token (`claude setup-token` output). Alternative to
+      `anthropic_api_key` — when set, the agent runs against the user's
+      Claude subscription instead of API billing. At least one of the two
+      must be provided.
+    required: false
+    default: ""
   github_token:
     description: >
       GitHub token the agent uses for API calls and git push. Typically
@@ -57,6 +68,7 @@ runs:
       env:
         PROMPT: ${{ inputs.prompt }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         OVERRIDE_GITHUB_TOKEN: ${{ inputs.override_github_token }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
@@ -68,12 +80,19 @@ runs:
         # its own source tree instead.
         export GITHUB_ACTION_PATH="$ACTION_PATH"
         export CLAUDE_ARGS="--permission-mode bypassPermissions"
+        # Require at least one of api_key / oauth_token. Fail fast with a
+        # clear message rather than letting the action silently degrade.
+        if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+          echo "::error::Neither anthropic_api_key nor claude_code_oauth_token was provided. Set one in the caller workflow."
+          exit 1
+        fi
         ALL_INPUTS="$(jq -nc \
           --arg prompt "$PROMPT" \
           --arg api_key "$ANTHROPIC_API_KEY" \
+          --arg oauth_token "$CLAUDE_CODE_OAUTH_TOKEN" \
           --arg gh_token "$GITHUB_TOKEN" \
           --arg claude_args "$CLAUDE_ARGS" \
           --arg extra_perms "$ADDITIONAL_PERMISSIONS" \
-          '{prompt: $prompt, anthropic_api_key: $api_key, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
+          '{prompt: $prompt, anthropic_api_key: $api_key, claude_code_oauth_token: $oauth_token, github_token: $gh_token, claude_args: $claude_args, additional_permissions: $extra_perms}')"
         export ALL_INPUTS
         bun run "$GITHUB_ACTION_PATH/src/entrypoints/run.ts"

--- a/.github/workflows/openspec-flow.yaml
+++ b/.github/workflows/openspec-flow.yaml
@@ -358,6 +358,7 @@ jobs:
         uses: ./.github/actions/openspec-flow-run-agent
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
           override_github_token: ${{ secrets.AGENT_GITHUB_TOKEN }}
           additional_permissions: ${{ env.AGENT_ADDITIONAL_PERMISSIONS }}
@@ -700,6 +701,7 @@ jobs:
         uses: ./.github/actions/openspec-flow-run-agent
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
           override_github_token: ${{ secrets.AGENT_GITHUB_TOKEN }}
           additional_permissions: ${{ env.AGENT_ADDITIONAL_PERMISSIONS }}
@@ -908,6 +910,7 @@ jobs:
         uses: ./.github/actions/openspec-flow-run-agent
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.AGENT_GITHUB_TOKEN || github.token }}
           override_github_token: ${{ secrets.AGENT_GITHUB_TOKEN }}
           additional_permissions: ${{ env.AGENT_ADDITIONAL_PERMISSIONS }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,8 @@ All set under repo Settings → Secrets and variables → Actions:
 - `NPM_TOKEN` — npm "Automation" / granular token with `package: write` on the `@dwmkerr` scope. Generate at npmjs.com → Access Tokens. Used by `deploy-npm` job in `deploy.yaml`.
 - `PARTYKIT_TOKEN` — generate with `npx partykit token generate` on a machine logged in as the relay owner (`dwmkerr`). Used by `deploy-partykit` job in `deploy.yaml`. Rotate by regenerating and pasting the new value into Actions secrets.
 - `CODECOV_TOKEN` — upload coverage from `validate` job.
-- `ANTHROPIC_API_KEY` — used by Claude-driven workflows (agent-actions, openspec-flow, security-review).
+- `ANTHROPIC_API_KEY` — used by Claude-driven workflows (agent-actions, openspec-flow, security-review). One of `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` must be set.
+- `CLAUDE_CODE_OAUTH_TOKEN` — alternative to `ANTHROPIC_API_KEY`: runs Claude Code against your subscription instead of API billing. Generate with `claude setup-token` locally (requires the Claude Code CLI logged in to a Pro/Max subscription), paste into this secret. When both are set, the action prefers OAuth.
 - `AGENT_GITHUB_TOKEN` — PAT used by agent workflows that need repo write scope beyond the default `GITHUB_TOKEN`.
 
 `PARTYKIT_LOGIN` is the partykit username (currently `dwmkerr`). It is **not** a secret — it's hardcoded at the workflow `env:` level in `deploy.yaml`. Change it there if the relay account changes.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@
   </p>
 </p>
 
-## Quickstart
-
 ```bash
 npx @dwmkerr/livedown share ./your-file.md
 ```


### PR DESCRIPTION
Lets the flow run against a Claude Code subscription (`claude setup-token`) instead of API billing. Both credentials supported as repo secrets; when both set, OAuth wins. Composite fails fast if neither is set.