### PR TITLE
docs(readme): add OpenSpec Flow section + low-credit troubleshooting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,6 @@
 # Contributing
 
-## Getting Started
-
-```bash
-git clone git@github.com:dwmkerr/livedown.git
-cd livedown
-npm install
-npm run build
-npm link
-livedown share ./README.md
-```
-
-## Development
-
-Run the relay locally:
-
-```bash
-npx partykit dev
-```
-
-In another terminal, share a file against the local relay:
-
-```bash
-PARTYKIT_HOST=localhost:1999 npx ts-node src/cli.ts share README.md
-```
+See the [Developer Guide](README.md#developer-guide) in the README for how to clone, build, and run the stack locally.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
   <h3 align="center">Share a local markdown file and collaborate live in a browser and across machines.</h3>
   <p align="center">
     <a href="#quickstart">Quickstart</a> |
-    <a href="#docker">Docker</a> |
-    <a href="#how-it-works">How It Works</a> |
-    <a href="#commands">Commands</a>
+    <a href="#commands">Commands</a> |
+    <a href="#developer-guide">Developer Guide</a> |
+    <a href="#security">Security</a> |
+    <a href="#advanced">Advanced</a> |
+    <a href="#how-it-works">How It Works</a>
   </p>
-
-
 
   <p align="center">
     <a href="https://github.com/dwmkerr/livedown/actions/workflows/cicd.yaml"><img src="https://github.com/dwmkerr/livedown/actions/workflows/cicd.yaml/badge.svg" alt="cicd"></a>
@@ -18,11 +18,23 @@
   </p>
 </p>
 
+## Quickstart
+
+<p align="center">
+  <img src="docs/terminal-share.svg" alt="livedown share terminal output" width="720">
+</p>
+
 ```bash
 npx @dwmkerr/livedown share ./your-file.md
 ```
 
-Open the printed URL — anyone with the link can view your document in real time. To edit, they need the edit key.
+- Press **`o`** to open the printed URL in your browser, or copy it and send it to anyone you want to view the file.
+- Press **`c`** to copy the edit key and send it — privately — to anyone you want to let edit.
+- Press **`q`** to stop sharing.
+
+The URL alone grants view access. Only people who also hold the edit key can change the file.
+
+<!-- TODO: screenshot of the livedown browser viewer -->
 
 ## Commands
 
@@ -39,17 +51,60 @@ Options:
 - `-e, --editor <name>` — Your name shown to viewers
 - `-k, --edit-key <key>` — Edit key (auto-generated if omitted)
 
-## Docker
+## Developer Guide
 
-Run Livedown without installing Node.js by using the published Docker image.
+```bash
+git clone git@github.com:dwmkerr/livedown.git
+cd livedown
+npm install
+npm run build
+npm link
+livedown share ./README.md
+```
+
+### Run the full stack locally
+
+For rapid iteration on the browser viewer (`public/index.html`) or the relay, run everything on your machine — no deployed relay required.
+
+```bash
+npx partykit dev
+```
+
+PartyKit serves the relay *and* `public/` on `http://localhost:1999` with caching disabled, so edits to `public/index.html` show up on browser refresh.
+
+In another terminal, share a file against the local relay:
+
+```bash
+PARTYKIT_HOST=localhost:1999 npx ts-node src/cli.ts share ./tests/documents/empty.md
+```
+
+The CLI prints a `http://localhost:1999/#…` URL. Open it and iterate.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for pull request requirements.
+
+## Security
+
+Livedown writes remote content to your local disk, so every update is signed with **Ed25519** and verified by three independent layers before anything lands on your filesystem:
+
+- The **relay** rejects pushes without a valid signature.
+- The **watcher** on your machine re-verifies every incoming update before writing to disk.
+- The **browser** checks that any entered edit key matches the room's public key before it will send a push.
+
+The URL is a locator, not a credential — it is safe to share. The edit key is the credential and must stay private.
+
+See [docs/architecture.md](docs/architecture.md) for the full security model, including the keypair lifecycle and defense-in-depth table.
+
+## Advanced
+
+### Docker
+
+Running Livedown in Docker isolates it from your local filesystem — only the directory you bind-mount is visible to the CLI. Useful as an extra security boundary when running untrusted documents.
 
 ```bash
 docker run --rm -v "$(pwd):/data" ghcr.io/dwmkerr/livedown share /data/notes.md
 ```
 
-The `--rm` flag removes the container on exit. The `-v "$(pwd):/data"` flag bind-mounts your current directory into `/data` inside the container so the CLI can read your local file.
-
-Pass optional flags after the image name exactly as you would with the CLI:
+Pass additional CLI flags after the image name:
 
 ```bash
 docker run --rm -v "$(pwd):/data" ghcr.io/dwmkerr/livedown share /data/notes.md \
@@ -57,74 +112,33 @@ docker run --rm -v "$(pwd):/data" ghcr.io/dwmkerr/livedown share /data/notes.md 
   --edit-key <your-edit-key>
 ```
 
-> **Platform note:** The published image targets `linux/amd64`. ARM users (Apple Silicon, Raspberry Pi, etc.) should build the image locally: `docker build -t livedown-local .`
+> **Platform note:** The published image targets `linux/amd64`. ARM users (Apple Silicon, Raspberry Pi) should build locally: `docker build -t livedown-local .`
 
 ## How It Works
 
 ```
- Your Machine             Relay (PartyKit)          Collaborator
+ Your Machine             Relay                    Collaborator
  ┌──────────┐            ┌──────────────┐          ┌──────────┐
  │ notes.md │───signed──▶│  Verify sig  │──update─▶│ Browser  │
  │          │◀──verify───│  Broadcast   │◀─signed──│          │
  └──────────┘            └──────────────┘          └──────────┘
-   watcher                 Cloudflare                viewer
-   (Node.js)               Workers                   (HTML)
 ```
 
-Livedown has three components:
+Livedown is three pieces:
 
-1. **CLI / Watcher** (`src/cli.ts`, `src/watcher.ts`) — watches a local markdown file for changes, pushes signed updates to the relay via WebSocket, and writes verified incoming updates to disk.
+1. A **CLI** on your machine watches your markdown file and pushes signed updates when it changes.
+2. A **relay** in the cloud forwards those updates to everyone connected to the same document.
+3. A **browser viewer** renders the document live, and — with the edit key — lets collaborators edit it back.
 
-2. **Relay** (`src/party/livedown.ts`) — a [PartyKit](https://partykit.io) server running on Cloudflare Workers. Accepts WebSocket connections, verifies Ed25519 signatures on push messages, and broadcasts verified updates to all connected clients.
+Details on the state machine, message protocol, security model, and the PartyKit / Cloudflare Workers relay setup live in [docs/architecture.md](docs/architecture.md).
 
-3. **Browser Viewer** (`public/index.html`) — renders the shared markdown with live preview and a CodeMirror editor. Viewers can read freely; editing requires the edit key.
+## OpenSpec Flow
 
-The CLI only prints the shareable URL **after** the relay acknowledges the sharer is registered. This means viewers can never arrive before the sharer is ready. The browser has an explicit state machine (`loading` / `live` / `offline` / `notfound`) driven entirely by relay messages — no timeouts, no guessing.
+This repo uses **OpenSpec Flow** — a GitHub Actions workflow that drives a Claude Code agent through the full OpenSpec lifecycle: issues become spec PRs, spec PRs become implementation PRs, and either can be refined on demand by adding the `openspec:start` label. See [`CLAUDE.md`](CLAUDE.md) for agent permission setup, secret rotation, and project conventions.
 
-For the complete protocol, state machine, and message types, see [`docs/architecture.md`](docs/architecture.md).
+### Troubleshooting
 
-### Key Libraries
-
-| Library | Used In | Purpose |
-|---------|---------|---------|
-| [tweetnacl](https://github.com/nickolay/nickolay/tweetnacl-js) | CLI, watcher, browser (CDN) | Ed25519 signing and verification |
-| [@noble/curves](https://github.com/paulmillr/noble-curves) | Relay | Ed25519 verification (pure ESM, Cloudflare Workers compatible) |
-| [PartyKit](https://partykit.io) | Relay | WebSocket relay infrastructure on Cloudflare Workers |
-| [CodeMirror](https://codemirror.net) | Browser | Markdown editor |
-| [marked](https://marked.js.org) | Browser | Markdown to HTML rendering |
-| [chokidar](https://github.com/paulmillr/chokidar) | Watcher | File system change detection |
-| [commander](https://github.com/tj/commander.js) | CLI | Command-line argument parsing |
-
-### Security
-
-Livedown uses **Ed25519 asymmetric signing** to protect the sharer's local files from unauthorized edits.
-
-When the sharer runs `livedown share`, the CLI generates an Ed25519 keypair:
-
-- **Edit key** (private key seed, 64 hex chars) — shared only with trusted editors
-- **Public key** — sent to the relay and broadcast to all viewers
-
-Every push message is signed with the private key. Three independent verification points enforce authorization:
-
-| Layer | Has | Verifies | Rejects |
-|-------|-----|----------|---------|
-| **Relay** | Public key | Signature on every push | Unsigned or invalid pushes are never broadcast |
-| **Watcher** | Private key (derives public key) | Signature on incoming updates | Forged updates are never written to disk |
-| **Browser** | Public key (from relay) | Edit key matches public key on entry | Wrong key is rejected before any push |
-
-This means even a compromised relay cannot forge updates that the local watcher would accept — the watcher independently verifies every signature before writing to disk.
-
-### PartyKit and Cloudflare Workers
-
-The relay runs on [PartyKit](https://partykit.io), which deploys to [Cloudflare Workers](https://workers.cloudflare.com). The relay uses [@noble/curves](https://github.com/paulmillr/noble-curves) for Ed25519 signature verification — a pure ESM library with no Node.js dependencies that bundles cleanly in Cloudflare's esbuild pipeline.
-
-The CLI and browser use [tweetnacl](https://github.com/nickolay/nickolay/tweetnacl-js) for Ed25519 operations. Both libraries implement RFC 8032 Ed25519 and produce compatible signatures.
-
-Rooms are ephemeral — they exist only while connections are active and have no persistent storage. The public key is held in memory for the room's lifetime and must be re-registered on each sharing session.
-
-## Developer Guide
-
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+- **Agent runs don't produce output, or produce very limited results.** Known issue with upstream [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action/issues/874): if the Anthropic account's credit is too low or unavailable, the SDK ends the run after a short number of turns with an error that is not propagated up to the workflow. The step reports success, but no branch or PR is created — impl PRs contain only archived spec content, issue state flips to `openspec:review` with nothing to review. Mitigation: top up credit on [console.anthropic.com](https://console.anthropic.com/), or set `CLAUDE_CODE_OAUTH_TOKEN` (see [`CLAUDE.md` → Secrets](CLAUDE.md)) to run against a Claude subscription instead of API billing. Tracked in [#98](https://github.com/dwmkerr/livedown/issues/98).
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -261,10 +261,35 @@ Two people share a file across machines. One is the leader, the other joins and 
 
 See [Security Principles](../.claude/agents/security.md) for the full set of rules.
 
-- **Ed25519 signing** - pushes are signed with the edit key (private), verified with the public key
-- **Defense in depth** - relay verifies before broadcasting; watcher verifies before writing to disk
-- **URLs are locators, not credentials** - the viewer URL is safe to share publicly
-- **No custom crypto** - tweetnacl (Node/browser) and @noble/curves (relay) only
+Livedown uses **Ed25519 asymmetric signing** to protect the sharer's local files from unauthorized edits. When the sharer runs `livedown share`, the CLI generates an Ed25519 keypair:
+
+- **Edit key** (private key seed, 64 hex chars) — shared only with trusted editors.
+- **Public key** — sent to the relay and broadcast to all viewers.
+
+Every push message is signed with the private key. Three independent verification points enforce authorization:
+
+| Layer | Has | Verifies | Rejects |
+|-------|-----|----------|---------|
+| **Relay** | Public key | Signature on every push | Unsigned or invalid pushes are never broadcast |
+| **Watcher** | Private key (derives public key) | Signature on incoming updates | Forged updates are never written to disk |
+| **Browser** | Public key (from relay) | Edit key matches public key on entry | Wrong key is rejected before any push |
+
+A compromised relay still cannot forge updates that the local watcher would accept — the watcher re-verifies every signature before writing to disk.
+
+Principles:
+
+- **Ed25519 signing** — pushes signed with the edit key (private), verified with the public key.
+- **Defense in depth** — relay verifies before broadcasting; watcher verifies before writing to disk.
+- **URLs are locators, not credentials** — the viewer URL is safe to share publicly.
+- **No custom crypto** — [tweetnacl](https://github.com/dchest/tweetnacl-js) (Node/browser) and [@noble/curves](https://github.com/paulmillr/noble-curves) (relay) only.
+
+## PartyKit and Cloudflare Workers
+
+The relay runs on [PartyKit](https://partykit.io), which deploys to [Cloudflare Workers](https://workers.cloudflare.com). The relay uses [@noble/curves](https://github.com/paulmillr/noble-curves) for Ed25519 signature verification — a pure ESM library with no Node.js dependencies that bundles cleanly in Cloudflare's esbuild pipeline.
+
+The CLI and browser use [tweetnacl](https://github.com/dchest/tweetnacl-js) for Ed25519 operations. Both libraries implement RFC 8032 Ed25519 and produce compatible signatures.
+
+Rooms are ephemeral — they exist only while connections are active and have no persistent storage. The public key is held in memory for the room's lifetime and must be re-registered on each sharing session.
 
 ## What must stay in sync
 

--- a/public/index.html
+++ b/public/index.html
@@ -32,14 +32,13 @@
       padding: 0 12px; height: 100%;
       border-right: 1px solid #313244; flex-shrink: 0;
     }
-    #sb-file   { color: #89b4fa; font-weight: 600; }
+    #sb-file   { color: #89b4fa; }
     #sb-owner  { color: #a6e3a1; }
     #sb-repo   { color: #89b4fa; text-decoration: none; }
     #sb-repo:hover { text-decoration: underline; }
     #sb-lastedit { color: #cba6f7; }
 
     /* Connection dot */
-    #sb-status { border-right: none; border-left: 1px solid #313244; }
     #sb-dot { width: 7px; height: 7px; border-radius: 50%; background: #6c7086; transition: background .4s; }
     #sb-dot.live    { background: #a6e3a1; }
     #sb-dot.offline { background: #f38ba8; }
@@ -49,7 +48,7 @@
     #sb-join { cursor: pointer; }
     #sb-join:hover { background: #313244; }
     #sb-join-url {
-      color: #89b4fa; text-decoration: none; font-weight: 500;
+      color: #89b4fa; text-decoration: none;
       max-width: 220px; overflow: hidden; text-overflow: ellipsis;
       display: inline-block; vertical-align: middle;
     }
@@ -321,22 +320,22 @@
   </div>
   <!-- spacer pushes right-side items to the edge -->
   <div style="flex:1"></div>
-  <div class="sb-seg" id="sb-edits-seg" style="display:none">
+  <div class="sb-seg" id="sb-status" title="Connection status">
+    <div id="sb-dot"></div>
+    <span id="sb-label">connecting…</span>
+  </div>
+  <div class="sb-seg" id="sb-edits-seg" style="display:none" title="Recent edits — click to see history">
     <span style="opacity:.5">📊</span>
     <span id="sb-edits-count">0 edits</span>
   </div>
-  <a class="sb-seg" href="https://github.com/dwmkerr/livedown" target="_blank" title="GitHub" style="text-decoration:none;border-right:none">
-    <svg style="width:14px;height:14px;opacity:.5" viewBox="0 0 16 16" fill="#cdd6f4"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-  </a>
-  <div id="profile">
+  <div id="profile" title="Your identity in this document">
     <div id="profile-avatar">?</div>
     <span id="profile-name">connecting…</span>
     <span id="profile-access"></span>
   </div>
-  <div class="sb-seg" id="sb-status">
-    <div id="sb-dot"></div>
-    <span id="sb-label">connecting…</span>
-  </div>
+  <a class="sb-seg" href="https://github.com/dwmkerr/livedown" target="_blank" title="livedown on GitHub" style="text-decoration:none;border-right:none">
+    <svg style="width:14px;height:14px;opacity:.5" viewBox="0 0 16 16" fill="#cdd6f4"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+  </a>
 </div>
 
 <div id="edits-popover"></div>


### PR DESCRIPTION
New top-level `## OpenSpec Flow` section with a Troubleshooting entry for the low-Anthropic-credit silent no-op symptom. Links to tracking issue dwmkerr/openspec-flow#74 and upstream anthropics/claude-code-action#874.