### PR TITLE
fix(run-agent): OAuth token takes precedence; API key suppressed when set

### DIFF
--- a/.github/actions/openspec-flow-run-agent/action.yml
+++ b/.github/actions/openspec-flow-run-agent/action.yml
@@ -86,9 +86,18 @@ runs:
           echo "::error::Neither anthropic_api_key nor claude_code_oauth_token was provided. Set one in the caller workflow."
           exit 1
         fi
+        # Prefer OAuth when set: suppress ANTHROPIC_API_KEY so the Claude
+        # Agent SDK cannot fall through to it. Without this, SDK default
+        # precedence is to try the API key first, which burns API credit
+        # even when the caller wanted subscription-backed auth.
+        if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+          echo "Using CLAUDE_CODE_OAUTH_TOKEN (subscription auth); ANTHROPIC_API_KEY ignored for this run."
+          ANTHROPIC_API_KEY=""
+          unset ANTHROPIC_API_KEY
+        fi
         ALL_INPUTS="$(jq -nc \
           --arg prompt "$PROMPT" \
-          --arg api_key "$ANTHROPIC_API_KEY" \
+          --arg api_key "${ANTHROPIC_API_KEY:-}" \
           --arg oauth_token "$CLAUDE_CODE_OAUTH_TOKEN" \
           --arg gh_token "$GITHUB_TOKEN" \
           --arg claude_args "$CLAUDE_ARGS" \


### PR DESCRIPTION
Run #24788400635 failed with 'Credit balance is too low' despite `CLAUDE_CODE_OAUTH_TOKEN` being set — Claude Agent SDK defaults to the API key when both are present. Explicitly suppress the API key when OAuth is configured.