### PR TITLE
spec: add --private flag for view-key protection

### DIFF
--- a/openspec/changes/add-private-flag/design.md
+++ b/openspec/changes/add-private-flag/design.md
@@ -1,0 +1,111 @@
+## Design
+
+### Key generation
+
+The CLI already generates one Ed25519 keypair (the edit key). With `--private`, it generates a second, independent Ed25519 keypair (the view key). Same primitive, same library (`tweetnacl`), same printing convention (64-char hex seed).
+
+```
+livedown share ./file.md --private
+
+  Watching  ./file.md
+  Join      https://livedown.dev/#<room>
+  View key  a81b...              (required to read)
+  Edit key  f7a2...              (required to write)
+  o open  c copy edit key  v copy view key  q quit
+```
+
+### Relay state
+
+The relay already tracks one public key (edit). It adds an optional second:
+
+```
+publicKey:      string | undefined   // edit public key  (existing)
+viewPublicKey:  string | undefined   // view public key  (new, set only for --private)
+authed:         Set<string>          // connection IDs that proved view-key knowledge
+```
+
+### Init field rename
+
+Today the relay sends `protected: !!publicKey` in `init`. This conflates "edit is protected" with "view is protected". Rename:
+
+| Old | New |
+|-----|-----|
+| `protected` | `editProtected` |
+| —           | `viewProtected` |
+
+Browsers on the old field can continue to read `protected` for one release via a shim if needed — but since the relay is deployed alongside the browser HTML that it serves, a clean rename is simplest.
+
+### Authentication flow (challenge-response)
+
+Viewer connects. If room is view-protected, relay sends init **without content**:
+
+```
+Relay → Viewer
+{
+  type: "init",
+  hasSharer: true,
+  editProtected: true,
+  viewProtected: true,
+  publicKey: "<edit pub>",
+  viewPublicKey: "<view pub>",
+  content: null,
+  meta: null
+}
+```
+
+Viewer prompts for view key. On entry, viewer asks for a challenge:
+
+```
+Viewer → Relay    { type: "auth-request" }
+Relay  → Viewer   { type: "auth-challenge", nonce: "<random 32 bytes hex>" }
+Viewer → Relay    { type: "auth-response", signature: "<sign(nonce, viewPriv)>" }
+Relay verifies signature against viewPublicKey.
+  OK    → mark conn as authed, send { type: "init-content", content, meta }
+  Fail  → send { type: "auth-error", reason: "bad-view-key" }
+```
+
+The relay broadcasts `update` messages only to connections in `authed` (plus the sharer themselves). Unauthed viewers receive nothing until they re-run the challenge.
+
+### Browser state machine
+
+```
+        Loading
+           │
+   ┌───────┼────────────────────┐
+   │       │                    │
+hasSharer=true,          hasSharer=true,         hasSharer=false
+viewProtected=false      viewProtected=true
+   │                            │                    │
+   ▼                            ▼                    ▼
+┌──────┐                  ┌─────────┐           ┌──────────┐
+│ Live │                  │ Locked  │           │ NotFound │
+└──────┘                  └────┬────┘           └──────────┘
+                               │ auth-ok
+                               ▼
+                           ┌──────┐
+                           │ Live │
+                           └──────┘
+```
+
+Locked shows: "This document is private. Enter view key." Nothing else — no title, no preview, no meta. Wrong-key handling mirrors the edit-key modal.
+
+### Why not one key?
+
+One-key (view key == edit key) simplifies UX but conflates grants. The issue explicitly calls out *"private collaboration where only invited participants should see anything"*, which is distinct from granting edit rights. Separate keys cost negligible extra complexity (same primitive, second seed) and keep grants independent. Future revocation can rotate view without kicking editors and vice-versa.
+
+### Why not content-side encryption?
+
+Encrypting the document blob would make the relay zero-trust for content, which is appealing. It is also a much larger change: every push + update carries ciphertext, a new symmetric key has to be derived and shared, and the protocol grows. Relay-gated auth reuses the existing Ed25519 primitive, keeps the message shape close to today's, and preserves the threat model (*signed pushes, independently verified*). Content-side encryption can be layered on later without breaking the flag semantics.
+
+### Security principles
+
+- **URLs are locators** — the join URL still contains no secret. The view key is shared out of band, exactly like the edit key.
+- **Defense in depth** — signatures continue to be verified at relay and watcher. View-key auth is an additional gate on content disclosure.
+- **Secrets never transit broadcast channels** — the view private seed never leaves the viewer. Only a nonce signature crosses the wire.
+- **No custom crypto** — reuses `tweetnacl` (CLI + browser) and `@noble/curves` (relay). Nonce is 32 random bytes from `crypto.getRandomValues`.
+
+### Edge cases
+
+- **Reconnect** — nonce + auth are scoped to the WebSocket. A disconnect requires re-auth. Browsers cache the entered view key in memory for the session so reconnect is transparent.
+- **Sharer-only view** — a sharer is implicitly authed (they know the edit key, but the view key is separate). To keep things simple, `set-token` from a sharer also marks that connection as authed for view purposes. Rationale: a sharer that does not know the view key cannot have created the room.
+- **Second sharer joining a private room** (future `livedown join`) — joiner must supply both `--edit-key` and `--view-key`. Out of scope for this change but noted for protocol compatibility.

--- a/openspec/changes/add-private-flag/proposal.md
+++ b/openspec/changes/add-private-flag/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Today anyone with the join URL can view the shared document — only editing requires the edit key. URLs leak through Slack previews, browser history, screen shares. A `--private` flag lets the sharer require a key to view as well, giving defense in depth when the URL is sensitive.
+
+Issue: [#16 — feat: add --private flag to require a key for viewing](https://github.com/dwmkerr/livedown/issues/16).
+
+## What Changes
+
+- Add `--private` flag to `livedown share`. Opt-in. Default behaviour unchanged.
+- When `--private` is set, the CLI generates a **view key** in addition to the existing edit key. Same shape: Ed25519 keypair, private seed printed as 64 hex chars, public key registered with the relay.
+- Relay withholds document content from any viewer that has not proven knowledge of the view key.
+- Browser viewer adds a **Locked** state: prompts for view key before rendering any content.
+- Proof-of-knowledge uses a challenge-response signed with the view private key (same primitive as edit signing). No secret ever crosses the wire.
+
+## Capabilities
+
+### New Capabilities
+
+- `private-sharing` — per-document view-key gating on top of the existing edit-key model.
+
+### Modified Capabilities
+
+- None. Edit-key flow is untouched.
+
+## Impact
+
+- `src/cli.ts` — parse `--private`, generate second keypair, print view key alongside edit key, add copy hotkey for view key.
+- `src/watcher.ts` — send view public key to relay on `set-token` when private.
+- `src/party/livedown.ts` — store optional view public key, gate `init` content and `update` broadcasts on per-connection auth flag, issue nonces, verify viewer signatures.
+- `public/index.html` — new Locked state UI, view-key entry flow, challenge-response signing in browser.
+- `docs/architecture.md`, `README.md` — document the private flag, new state, and message types.
+- No breaking changes. Existing public rooms keep working unchanged.

--- a/openspec/changes/add-private-flag/specs/private-sharing/spec.md
+++ b/openspec/changes/add-private-flag/specs/private-sharing/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Private flag opts a shared document into view-key protection
+The `livedown share` command SHALL accept a `--private` flag that, when set, generates a **view key** (a second Ed25519 keypair, distinct from the edit key) and requires viewers to prove knowledge of that key before the relay will disclose document content. Without the flag, sharing behaviour SHALL be unchanged.
+
+#### Scenario: Default sharing is unchanged
+- **WHEN** a user runs `livedown share ./file.md` without `--private`
+- **THEN** the relay SHALL send document content to all connecting viewers as it does today, and no view key SHALL be generated
+
+#### Scenario: Private sharing generates a view key
+- **WHEN** a user runs `livedown share ./file.md --private`
+- **THEN** the CLI SHALL generate a second Ed25519 keypair, print the view key on its own line alongside the edit key, and register the view public key with the relay
+
+### Requirement: CLI prints and offers to copy the view key
+When `--private` is active, the CLI SHALL display the view key in the share info block and provide a keyboard shortcut to copy it, matching the ergonomics of the existing edit-key display.
+
+#### Scenario: View key appears in the info block
+- **WHEN** the CLI starts sharing a private document
+- **THEN** the info block SHALL include a line of the form `View key  <64 hex chars>` immediately above or below the existing `Edit key` line
+
+#### Scenario: Hotkey copies the view key
+- **WHEN** the user presses `v` in the running CLI for a private session
+- **THEN** the view key SHALL be copied to the system clipboard and a confirmation message SHALL be printed
+
+### Requirement: Relay withholds content from unauthed viewers in private rooms
+In a private room, the relay SHALL omit `content` and `meta` from the `init` message sent to any connection that has not yet proven knowledge of the view key, and SHALL NOT broadcast `update` messages to such connections.
+
+#### Scenario: Initial connection sees no content
+- **WHEN** a viewer connects to a private room without supplying any credential
+- **THEN** the `init` message received SHALL have `viewProtected: true` and SHALL NOT contain `content` or `meta`
+
+#### Scenario: Unauthed viewer is excluded from live updates
+- **WHEN** the sharer pushes an update to a private room and a connected viewer has not yet completed authentication
+- **THEN** the relay SHALL NOT send the `update` message to that viewer
+
+### Requirement: Relay authenticates viewers via a challenge-response signed with the view key
+The relay SHALL support an `auth-request` / `auth-challenge` / `auth-response` exchange in which the viewer signs a relay-issued nonce with the view private key and the relay verifies the signature against the stored view public key.
+
+#### Scenario: Valid signature unlocks content
+- **WHEN** a viewer sends `auth-response` with a valid Ed25519 signature over the nonce from the relay's preceding `auth-challenge`
+- **THEN** the relay SHALL mark the connection as authed and send an `init-content` message containing the current `content` and `meta`, after which the connection SHALL receive all subsequent `update` broadcasts
+
+#### Scenario: Invalid signature is rejected
+- **WHEN** a viewer sends `auth-response` with a signature that does not verify against the view public key
+- **THEN** the relay SHALL send an `auth-error` message, leave the connection unauthed, and continue withholding content
+
+#### Scenario: Nonce is single-use
+- **WHEN** a connection reuses a nonce from a prior challenge, or uses a nonce not issued to it
+- **THEN** the relay SHALL reject the `auth-response` regardless of signature validity
+
+### Requirement: Browser viewer presents a Locked state for private rooms
+The browser viewer SHALL render a **Locked** state whenever the initial `init` message reports `viewProtected: true` and the viewer has not yet authed. The Locked state SHALL NOT display the document title, content, preview, or metadata.
+
+#### Scenario: Locked state is entered from Loading
+- **WHEN** the browser receives `init` with `hasSharer: true` and `viewProtected: true`
+- **THEN** the viewer SHALL transition from Loading to Locked and show a prompt of the form "This document is private. Enter view key."
+
+#### Scenario: Correct view key transitions to Live
+- **WHEN** the user enters a view key whose derived public key matches `viewPublicKey` and the challenge-response succeeds
+- **THEN** the viewer SHALL transition to Live and render the document content returned in `init-content`
+
+#### Scenario: Wrong view key is reported inline
+- **WHEN** the user enters a view key that does not match or whose signature is rejected
+- **THEN** the modal SHALL display an error, remain open, and keep the viewer in the Locked state
+
+### Requirement: Rename of relay init flag to distinguish edit vs view protection
+The relay's `init` and `sharer-here` messages SHALL expose separate `editProtected` and `viewProtected` boolean fields, replacing the existing `protected` field.
+
+#### Scenario: Edit-only protection (default sharing)
+- **WHEN** a sharer starts without `--private`
+- **THEN** the relay SHALL set `editProtected: true` and `viewProtected: false` in `init` and `sharer-here`
+
+#### Scenario: View-and-edit protection (private sharing)
+- **WHEN** a sharer starts with `--private`
+- **THEN** the relay SHALL set both `editProtected: true` and `viewProtected: true` in `init` and `sharer-here`, and include `viewPublicKey`
+
+### Requirement: View private seed never transits the network
+The view private seed SHALL remain on the viewer's machine at all times. Only signatures over relay-issued nonces SHALL be sent over the WebSocket; no part of the seed or derived private key material SHALL appear in any message to the relay.
+
+#### Scenario: Only signatures cross the wire
+- **WHEN** any message is sent from a viewer to the relay during authentication
+- **THEN** the message SHALL contain at most a signature and public metadata — never the seed, never the private key bytes

--- a/openspec/changes/add-private-flag/tasks.md
+++ b/openspec/changes/add-private-flag/tasks.md
@@ -1,0 +1,46 @@
+## 1. CLI
+
+- [ ] 1.1 Add `--private` boolean flag to `livedown share` in `src/cli.ts`
+- [ ] 1.2 Generate a second Ed25519 keypair (view key) when `--private` is set, using the same helper path as the edit key in `src/token.ts`
+- [ ] 1.3 Print the view key on its own line in the share info block, alongside the existing edit key
+- [ ] 1.4 Add a `v` keyboard shortcut to copy the view key; update the hotkey hint line
+- [ ] 1.5 Pass the view public key through to the watcher so it can be sent to the relay
+
+## 2. Watcher
+
+- [ ] 2.1 In `src/watcher.ts`, extend the `set-token` message to include `viewPublicKey` when the sharer is private
+- [ ] 2.2 No change to signing (edit key continues to sign pushes); view key is verification-only on the relay side
+
+## 3. Relay
+
+- [ ] 3.1 In `src/party/livedown.ts`, store optional `viewPublicKey` and a per-connection `authed: Set<string>`
+- [ ] 3.2 On `set-token`, accept and remember `viewPublicKey` on first call; reject mismatched values on subsequent sharers
+- [ ] 3.3 Rename `protected` field to `editProtected` in `init` and `sharer-here`; add `viewProtected` and `viewPublicKey` fields
+- [ ] 3.4 When `viewProtected` is true, omit `content` and `meta` from the initial `init` message for unauthed connections
+- [ ] 3.5 Handle `auth-request`: generate a 32-byte random nonce with `crypto.getRandomValues`, remember it per connection, send `auth-challenge`
+- [ ] 3.6 Handle `auth-response`: verify the signature against `viewPublicKey` using `@noble/curves`; on success, add conn to `authed` and send `init-content`; on failure send `auth-error`
+- [ ] 3.7 Gate `update` broadcasts on `authed` membership (plus the sharer connection IDs, which are implicitly authed)
+- [ ] 3.8 Unit-test the auth flow: valid sig unlocks content; wrong sig stays locked; unauthed conn never sees `update` messages
+
+## 4. Browser viewer
+
+- [ ] 4.1 In `public/index.html`, add a `Locked` state to the state machine, reachable from `Loading` when `viewProtected` is true
+- [ ] 4.2 Render a locked view: "This document is private. Enter view key." No title, preview, or meta is shown until authed
+- [ ] 4.3 Wire a view-key input modal mirroring the existing edit-key modal (wrong-key handling, paste support)
+- [ ] 4.4 On view-key entry, derive the Ed25519 keypair locally and verify it matches `viewPublicKey` before hitting the relay
+- [ ] 4.5 Implement the challenge-response: send `auth-request`, sign the returned nonce with the view private key, send `auth-response`
+- [ ] 4.6 On `init-content`, transition to `Live` and render as usual; on `auth-error`, show an inline error in the modal
+- [ ] 4.7 Cache the entered view key in memory for the WS session so reconnects re-auth transparently
+
+## 5. Tests
+
+- [ ] 5.1 Unit test the relay auth flow (valid nonce signature, invalid signature, tampered nonce)
+- [ ] 5.2 Unit test that `update` broadcasts skip unauthed connections in private rooms
+- [ ] 5.3 Playwright scenario: start `livedown share --private`, open URL, assert Locked state, enter wrong key (error), enter right key (Live)
+- [ ] 5.4 Playwright scenario: confirm an unauthed viewer never receives content even while a sharer is actively pushing updates
+
+## 6. Documentation
+
+- [ ] 6.1 Update `docs/architecture.md` — new state, new message types, renamed `protected` field, new security flow
+- [ ] 6.2 Update the README "How It Works" and add a short `--private` example to usage
+- [ ] 6.3 Update `CLAUDE.md` key-files notes if any new files are added (none expected)


### PR DESCRIPTION
## Summary
- OpenSpec change proposal for [#16](https://github.com/dwmkerr/livedown/issues/16) — `livedown share --private`
- Generates a **view key** alongside the edit key (second Ed25519 seed, 64 hex chars, printed in share info block)
- Relay withholds `content` / `update` until viewer proves knowledge of the view key via challenge-response
- Browser adds a **Locked** state before Live
- Renames relay `protected` flag → `editProtected` + new `viewProtected`
- Spec-only — no implementation in this PR

## For Krish
Four files to review under `openspec/changes/add-private-flag/`:
- `proposal.md` — the what and the why
- `design.md` — key generation, auth flow, state machine, rationale for two keys + relay-gated (vs content-encrypted)
- `tasks.md` — implementation breakdown
- `specs/private-sharing/spec.md` — normative requirements (SHALL-level)

Please push back on any of: one-key vs two-key choice, relay-gated vs content-encrypted, the `protected` → `editProtected`/`viewProtected` rename, and the Locked state UX copy.