### PR TITLE
fix: gate ANSI escapes on TTY to fix raw codes in piped output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,16 @@ import readline from "readline";
 import { Command } from "commander";
 import { startWatcher } from "./watcher";
 import { generateEditKeyPair, publicKeyFromEditKey } from "./token";
+import {
+  clearLine,
+  cyan,
+  dim,
+  green,
+  link,
+  red,
+  underline,
+  yellow,
+} from "./style";
 
 const pkg = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")
@@ -71,7 +81,7 @@ async function startSharing(
   // watcher is ready. The URL is only printed after the relay acks the sharer
   // so the user can never share a URL before the room is fully established.
   if (process.stdout.isTTY) {
-    process.stdout.write(`  \x1b[2mConnecting...\x1b[0m`);
+    process.stdout.write(`  ${dim("Connecting...")}`);
   } else {
     console.log("  Connecting...");
   }
@@ -79,29 +89,27 @@ async function startSharing(
   try {
     await startWatcher(filePath, doc, roomUrl, opts.editor, editKey, publicKey);
   } catch (err) {
-    if (process.stdout.isTTY) process.stdout.write("\r\x1b[2K");
+    process.stdout.write(clearLine());
     const msg = (err as Error).message;
-    console.error(`  \x1b[31m✗ ${msg}\x1b[0m`);
+    console.error(`  ${red(`✗ ${msg}`)}`);
     // --dev targets a local partykit server that the user must start in another
     // shell. Point them at it on any failure — connection-refused, timeout, etc.
     if (opts.dev) {
       console.error(
-        `  \x1b[2mIn another terminal run: \x1b[36mnpx partykit dev --port 1999\x1b[0m`
+        `  ${dim(`In another terminal run: ${cyan("npx partykit dev --port 1999")}`)}`
       );
     }
     process.exit(1);
   }
 
-  if (process.stdout.isTTY) process.stdout.write("\r\x1b[2K");
+  process.stdout.write(clearLine());
   console.log(
-    `  Join      \x1b[4m\x1b]8;;${viewerUrl}\x07${viewerUrl}\x1b]8;;\x07\x1b[24m \x1b[2m(press o to open)\x1b[0m`
+    `  Join      ${underline(link(viewerUrl))} ${dim("(press o to open)")}`
   );
-  console.log(
-    `  Edit key  \x1b[33m${editKey}\x1b[0m \x1b[2m(press c to copy)\x1b[0m\n`
-  );
+  console.log(`  Edit key  ${yellow(editKey)} ${dim("(press c to copy)")}\n`);
 
   if (process.stdin.isTTY) {
-    const hints = "\x1b[2m  o open  c copy key  q quit\x1b[0m";
+    const hints = dim("  o open  c copy key  q quit");
     process.stdout.write(hints);
     process.stdin.setRawMode(true);
     process.stdin.resume();
@@ -115,12 +123,12 @@ async function startSharing(
           const { default: clipboardy } = await import("clipboardy");
           await clipboardy.write(editKey);
           process.stdout.write(
-            "\x1b[2K\r  \x1b[32m✓ Edit key copied to clipboard\x1b[0m\n"
+            `${clearLine()}  ${green("✓ Edit key copied to clipboard")}\n`
           );
           process.stdout.write(hints);
         } catch {
           process.stdout.write(
-            "\x1b[2K\r  \x1b[31m✗ Could not copy to clipboard\x1b[0m\n"
+            `${clearLine()}  ${red("✗ Could not copy to clipboard")}\n`
           );
           process.stdout.write(hints);
         }
@@ -130,12 +138,12 @@ async function startSharing(
           const open = (await import("open")).default;
           await open(viewerUrl);
           process.stdout.write(
-            "\x1b[2K\r  \x1b[32m✓ Opened in browser\x1b[0m\n"
+            `${clearLine()}  ${green("✓ Opened in browser")}\n`
           );
           process.stdout.write(hints);
         } catch {
           process.stdout.write(
-            "\x1b[2K\r  \x1b[31m✗ Could not open browser\x1b[0m\n"
+            `${clearLine()}  ${red("✗ Could not open browser")}\n`
           );
           process.stdout.write(hints);
         }

--- a/src/style.ts
+++ b/src/style.ts
@@ -1,0 +1,28 @@
+// Gate ANSI styling on stdout being a TTY. Without this, escape codes leak
+// verbatim when output is captured (e.g. Vim's `:!`, pipes, log files).
+// FORCE_COLOR=0 also disables; FORCE_COLOR=1+ forces on.
+
+function enabled(): boolean {
+  const force = process.env.FORCE_COLOR;
+  if (force === "0") return false;
+  if (force && force !== "") return true;
+  return process.stdout.isTTY === true;
+}
+
+const wrap = (open: string, close: string) => (s: string) =>
+  enabled() ? `${open}${s}${close}` : s;
+
+export const dim = wrap("\x1b[2m", "\x1b[0m");
+export const red = wrap("\x1b[31m", "\x1b[0m");
+export const green = wrap("\x1b[32m", "\x1b[0m");
+export const yellow = wrap("\x1b[33m", "\x1b[0m");
+export const cyan = wrap("\x1b[36m", "\x1b[0m");
+export const underline = wrap("\x1b[4m", "\x1b[24m");
+
+export function link(url: string, text: string = url): string {
+  return enabled() ? `\x1b]8;;${url}\x07${text}\x1b]8;;\x07` : text;
+}
+
+export function clearLine(): string {
+  return enabled() ? "\x1b[2K\r" : "";
+}

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -4,6 +4,7 @@ import chokidar from "chokidar";
 import matter from "gray-matter";
 import WebSocket from "ws";
 import { signContent, verifySignature } from "./token";
+import { dim, red } from "./style";
 
 interface Meta {
   owner: string | null;
@@ -31,7 +32,7 @@ function parseMeta(
   };
 }
 
-const HINTS = "\x1b[2m  o open  c copy key  q quit\x1b[0m";
+const HINTS = dim("  o open  c copy key  q quit");
 let showHints = false;
 
 function log(msg: string): void {
@@ -122,7 +123,7 @@ export function startWatcher(
         }
         if (msg.type === "auth-rejected") {
           const who = msg.editor || "unknown";
-          log(`  \x1b[31m✗ ${who} — edit rejected (bad signature)\x1b[0m`);
+          log(`  ${red(`✗ ${who} — edit rejected (bad signature)`)}`);
           return;
         }
         if (msg.type !== "update") return;
@@ -130,7 +131,7 @@ export function startWatcher(
         // Verify signature before writing to disk
         if (msg.signature && publicKey) {
           if (!verifySignature(msg.content || "", msg.signature, publicKey)) {
-            log("  \x1b[31m✗ Rejected update — invalid signature\x1b[0m");
+            log(`  ${red("✗ Rejected update — invalid signature")}`);
             return;
           }
         }
@@ -159,11 +160,7 @@ export function startWatcher(
             .replace(/\n/g, " ")
             .trim()
             .slice(0, 60);
-          const dim = "\x1b[2m";
-          const reset = "\x1b[0m";
-          log(
-            `  ${dim}${who}${reset}  ${preview}${preview.length >= 60 ? "..." : ""}`
-          );
+          log(`  ${dim(who)}  ${preview}${preview.length >= 60 ? "..." : ""}`);
         }
       } catch {
         /* ignore malformed */


### PR DESCRIPTION
## Summary
- Color codes (`^[[33m`) and OSC 8 hyperlinks (`^]8;;URL^G`) leaked verbatim when stdout is not a TTY — visible in Vim `:!`, pipes, log files.
- Added `src/style.ts` with TTY-gated wrappers; replaced inline escapes in `cli.ts` + `watcher.ts`.
- Honors `FORCE_COLOR` (0 disables, set forces on, unset falls back to `isTTY`).
- TTY output byte-identical; piped output now plain text.

## Test plan
- [x] `npm run lint && npm run build && npm test` green
- [x] Smoke test: piped `livedown share` output free of escape codes
- [ ] Reviewer: verify TTY rendering unchanged in their terminal