### PR TITLE
docs(readme): add OpenSpec Flow actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <p align="center">
     <a href="https://github.com/dwmkerr/livedown/actions/workflows/cicd.yaml"><img src="https://github.com/dwmkerr/livedown/actions/workflows/cicd.yaml/badge.svg" alt="cicd"></a>
     <a href="https://github.com/dwmkerr/livedown/actions/workflows/deploy.yaml"><img src="https://github.com/dwmkerr/livedown/actions/workflows/deploy.yaml/badge.svg?event=workflow_dispatch" alt="deploy"></a>
+    <a href="https://github.com/dwmkerr/livedown/actions/workflows/openspec-flow.yaml"><img src="https://github.com/dwmkerr/livedown/actions/workflows/openspec-flow.yaml/badge.svg" alt="openspec flow"></a>
     <a href="https://www.npmjs.com/package/@dwmkerr/livedown"><img src="https://img.shields.io/npm/v/%40dwmkerr/livedown" alt="npm version"></a>
     <a href="https://codecov.io/gh/dwmkerr/livedown"><img src="https://codecov.io/gh/dwmkerr/livedown/graph/badge.svg" alt="codecov"></a>
   </p>


### PR DESCRIPTION
## Summary
- Add OpenSpec Flow GitHub Actions badge to README, linking to the `openspec-flow.yaml` workflow runs.