### PR TITLE
feat(openspec-flow): shim the external reusable workflow

### DIFF
--- a/.github/workflows/openspec-flow.yml
+++ b/.github/workflows/openspec-flow.yml
@@ -1,0 +1,19 @@
+# Maintained by openspec-flow. Edit the `uses:` ref to upgrade.
+# Docs: https://github.com/dwmkerr/openspec-flow
+name: openspec-flow
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled, closed]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+jobs:
+  flow:
+    uses: dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENSPEC_FLOW_APP_ID: ${{ secrets.OPENSPEC_FLOW_APP_ID || '' }}
+      OPENSPEC_FLOW_PRIVATE_KEY: ${{ secrets.OPENSPEC_FLOW_PRIVATE_KEY || '' }}

--- a/README.md
+++ b/README.md
@@ -152,3 +152,16 @@ MIT
 ---
 
 <sub>UI prototyped on [Claude Design](https://claude.ai/design/p/68395513-244f-402c-b6ee-77499c42f583?file=Livedown+Designs.html). See [`design/`](design/) for artifacts, [`docs/design.md`](docs/design.md) for the implementation contract.</sub>
+
+<!-- openspec-flow install-start -->
+## openspec-flow
+
+This repo uses [openspec-flow](https://github.com/dwmkerr/openspec-flow) to drive spec-driven development from GitHub issues.
+
+1. Open an issue describing the feature, fix, or task.
+2. Add the `openspec:go` label.
+3. openspec-flow opens a **spec PR** (`openspec:spec`). Review, comment, iterate (add `openspec:go` to the PR to re-run). Merge when happy.
+4. openspec-flow opens an **impl PR** (`openspec:impl`). Review, iterate, merge. The originating issue closes automatically.
+
+Required Actions secret: `ANTHROPIC_API_KEY`.
+<!-- openspec-flow install-end -->


### PR DESCRIPTION
## Summary

Pairs with #122 (which removed the in-repo implementation). Adds the shim that calls upstream.

- \`.github/workflows/openspec-flow.yml\` — thin caller of \`dwmkerr/openspec-flow/.github/workflows/openspec-flow.yml@main\`. Forwards \`ANTHROPIC_API_KEY\` (mandatory) and \`OPENSPEC_FLOW_APP_ID\` / \`OPENSPEC_FLOW_PRIVATE_KEY\` (optional GitHub App auth — falls back to default \`GITHUB_TOKEN\` when unset).
- README — small \`openspec-flow\` install block with HTML markers so upstream can update it in place. Describes the label-driven plan → impl flow.

## Test plan

- [x] \`npm run lint && npm run build && npm test\` — green (19 tests).
- [ ] After merge: open a test issue, add \`openspec:go\` label, confirm the shim fires and a spec PR opens.