### PR TITLE
ci: bump actions/checkout + setup-node to v5

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -31,8 +31,8 @@ jobs:
       matrix:
         node-version: [22.x, 24.x]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -73,7 +73,7 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Dispatch deploy workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,10 +44,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           registry-url: "https://registry.npmjs.org"
@@ -72,10 +72,10 @@ jobs:
     # minutes waiting on an interactive prompt.
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           cache: "npm"

--- a/.github/workflows/security-review.yaml
+++ b/.github/workflows/security-review.yaml
@@ -16,7 +16,7 @@ jobs:
       # Checkout from BASE (main), not the PR branch. This ensures the
       # workflow, agent definition, and prompt all come from trusted code.
       # We only read the PR diff via gh cli — never checkout PR code.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 


### PR DESCRIPTION
## Summary

- Bump `actions/checkout@v4` → `@v5` and `actions/setup-node@v4` → `@v5` across `cicd.yaml`, `deploy.yaml`, `security-review.yaml`.
- v5 releases run on Node.js 24; drops the deprecation warning surfaced on v0.1.6's deploy run and avoids the forced-default cutover on 2026-06-16.

## Test plan

- [ ] CI on this PR passes (validates the bump on real runners).
- [ ] Next deploy run shows no Node 20 deprecation annotation.