### PR TITLE
ci: bump codecov + release-please actions, cut 0.1.7

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -40,7 +40,7 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm run test:cov
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         if: matrix.node-version == env.NODE_LTS_VERSION
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
       releases_created: ${{ steps.release-please.outputs.releases_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release-please
         with:
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary

- Bump `codecov/codecov-action@v4` → `@v6`. Same `token` input we already pass.
- Bump `googleapis/release-please-action@v4` → `@v5`. Same `config-file` + `manifest-file` inputs we already pass.
- Both clear the Node.js 20 deprecation warning that #126 fixed for `checkout` + `setup-node`.

The commit footer carries `Release-As: 0.1.7` so once this merges, release-please opens the 0.1.7 release PR; merging that tags `v0.1.7` and auto-dispatches `deploy.yaml` with the new (verified) `NPM_TOKEN`.

## Test plan

- [ ] PR CI green (validates the action bumps on real runners).
- [ ] After merge: release-please opens `chore(main): release 0.1.7`.
- [ ] After release PR merge: `v0.1.7` tagged, deploy runs, npm + partykit jobs both green.