### PR TITLE
docs: drop stale OpenSpec Flow section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,16 +135,6 @@ Livedown is three pieces:
 
 Details on the state machine, message protocol, security model, and the PartyKit / Cloudflare Workers relay setup live in [docs/architecture.md](docs/architecture.md).
 
-## OpenSpec Flow
-
-This repo uses **OpenSpec Flow** — a GitHub Actions workflow that drives a Claude Code agent through the full OpenSpec lifecycle: issues become spec PRs, spec PRs become implementation PRs, and either can be refined on demand by adding the `openspec:start` label. See [`CLAUDE.md`](CLAUDE.md) for agent permission setup, secret rotation, and project conventions.
-
-### Troubleshooting
-
-- **Agent runs don't produce output, or produce very limited results.** Known issue with upstream [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action/issues/874): if the Anthropic account's credit is too low or unavailable, the SDK ends the run after a short number of turns with an error that is not propagated up to the workflow. The step reports success, but no branch or PR is created — impl PRs contain only archived spec content, issue state flips to `openspec:review` with nothing to review. Mitigation: top up credit on [console.anthropic.com](https://console.anthropic.com/), or set `CLAUDE_CODE_OAUTH_TOKEN` to run against a Claude subscription instead of API billing. Tracked in [#98](https://github.com/dwmkerr/livedown/issues/98).
-
-- **Both `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` set at once.** The Claude Agent SDK prefers the API key (same precedence as the local `claude` CLI), so OAuth is ignored. Delete whichever secret you don't want to use. See [`CLAUDE.md` → Secrets](CLAUDE.md) for rotation notes and Anthropic's [authentication docs](https://code.claude.com/docs/en/authentication) / [consumer terms](https://www.anthropic.com/legal/consumer-terms) before using OAuth in CI — sanctioned for personal use on your own repo, but firing on third-party events ([#838](https://github.com/anthropics/claude-code-action/issues/838)) has led to account bans.
-
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Remove hand-written OpenSpec Flow + Troubleshooting section (lines 138-146)
- Stale references: `openspec:start` / `openspec:review` / `openspec:failed` labels (retired) and issue #98 (transferred to dwmkerr/openspec-flow#74)
- Auto-managed `openspec-flow install-start/end` section (lines 156-167) already documents the current lifecycle with correct labels (`openspec:go` / `openspec:spec` / `openspec:impl`)